### PR TITLE
[FEAT/#11] 바텀 네비 디자인 반영

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/main/MainTab.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/main/MainTab.kt
@@ -14,22 +14,22 @@ enum class MainTab(
     val label: String
 ) {
     HOME(
-        iconRes = R.drawable.ic_launcher_background,
+        iconRes = R.drawable.ic_home,
         route = Home,
         label = "홈"
     ),
     CALENDAR(
-        iconRes = R.drawable.ic_launcher_background,
+        iconRes = R.drawable.ic_calendar,
         route = Calendar,
         label = "캘린더"
     ),
     CHALLENGE(
-        iconRes = R.drawable.ic_launcher_background,
+        iconRes = R.drawable.ic_challenge,
         route = Challenge,
         label = "챌린지"
     ),
     MYPAGE(
-        iconRes = R.drawable.ic_launcher_background,
+        iconRes = R.drawable.ic_mypage,
         route = MyPage,
         label = "마이"
     );

--- a/app/src/main/java/com/cherrish/android/presentation/main/component/MainBottomBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/main/component/MainBottomBar.kt
@@ -87,7 +87,8 @@ private fun RowScope.MainBottomBarItem(
         )
         Text(
             text = tab.label,
-            color = if (selected) CherrishTheme.colors.gray1000 else CherrishTheme.colors.gray500
+            color = if (selected) CherrishTheme.colors.gray1000 else CherrishTheme.colors.gray500,
+            style = CherrishTheme.typography.body3M12
         )
     }
 }

--- a/app/src/main/java/com/cherrish/android/presentation/main/component/MainBottomBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/main/component/MainBottomBar.kt
@@ -74,7 +74,8 @@ private fun RowScope.MainBottomBarItem(
     onClick: () -> Unit
 ) {
     Column(
-        modifier = Modifier.weight(1f)
+        modifier = Modifier
+            .weight(1f)
             .noRippleClickable(onClick = onClick),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp)

--- a/app/src/main/java/com/cherrish/android/presentation/main/component/MainBottomBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/main/component/MainBottomBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,6 +26,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.common.extension.noRippleClickable
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import com.cherrish.android.presentation.main.MainTab
 import kotlinx.collections.immutable.ImmutableList
@@ -44,25 +44,23 @@ fun MainBottomBar(
         enter = fadeIn() + slideIn { IntOffset(0, it.height) },
         exit = fadeOut() + slideOut { IntOffset(0, it.height) }
     ) {
-        Column(
-            modifier = Modifier.background(color = Color.White)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(50.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = CherrishTheme.colors.gray0)
+                .padding(top = 10.dp)
+                .padding(horizontal = 9.dp)
+                .navigationBarsPadding()
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(8.dp)
-                    .navigationBarsPadding()
-            ) {
-                tabs.forEach { tab ->
-                    key(tab.route) {
-                        MainBottomBarItem(
-                            tab = tab,
-                            selected = (tab == currentTab),
-                            onClick = { onTabSelected(tab) }
-                        )
-                    }
+            tabs.forEach { tab ->
+                key(tab.route) {
+                    MainBottomBarItem(
+                        tab = tab,
+                        selected = (tab == currentTab),
+                        onClick = { onTabSelected(tab) }
+                    )
                 }
             }
         }
@@ -77,7 +75,7 @@ private fun RowScope.MainBottomBarItem(
 ) {
     Column(
         modifier = Modifier.weight(1f)
-            .clickable(onClick = onClick),
+            .noRippleClickable(onClick = onClick),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
@@ -85,11 +83,11 @@ private fun RowScope.MainBottomBarItem(
             imageVector = ImageVector.vectorResource(id = tab.iconRes),
             modifier = Modifier.size(24.dp),
             contentDescription = null,
-            tint = if (selected) Color.Black else Color.Gray
+            tint = if (selected) Color.Unspecified else CherrishTheme.colors.gray500
         )
         Text(
             text = tab.label,
-            color = if (selected) Color.Black else Color.Gray
+            color = if (selected) CherrishTheme.colors.gray1000 else CherrishTheme.colors.gray500
         )
     }
 }

--- a/app/src/main/res/drawable/ic_calendar.xml
+++ b/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,11.053H21M3,11.053V19C3,20.105 3.895,21 5,21H19C20.105,21 21,20.105 21,19V11.053M3,11.053V6.895C3,5.79 3.895,4.895 5,4.895M21,11.053V6.895C21,5.79 20.105,4.895 19,4.895M13,4.895L11.769,4.895H10.5"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8,6L8,3"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF617B"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M16,6L16,3"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF617B"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_challenge.xml
+++ b/app/src/main/res/drawable/ic_challenge.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M17.5,4H5C3.895,4 3,4.895 3,6V19C3,20.105 3.895,21 5,21H18C19.105,21 20,20.105 20,19V15"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.5,10.5L12.295,14.717C12.678,15.142 13.34,15.16 13.745,14.755L21.5,7"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF617B"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12.1,21V17.4"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF617B"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.95,21H5.8C5.323,21 4.865,20.81 4.527,20.473C4.19,20.135 4,19.677 4,19.2V9.74C4,9.462 4.128,9.2 4.347,9.03L11.547,3.43C11.872,3.177 12.328,3.177 12.653,3.43L19.852,9.03C20.072,9.2 20.2,9.462 20.2,9.74V19.2C20.2,19.677 20.01,20.135 19.673,20.473C19.335,20.81 18.877,21 18.4,21H15.25"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_mypage.xml
+++ b/app/src/main/res/drawable/ic_mypage.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M8.597,9.159C8.597,6.568 11.252,2.953 14.529,2.955C14.74,2.955 13.881,8.136 16.472,10.727"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M16.534,6.587C15.489,5.629 15.204,4.199 15.348,3.528C15.383,3.365 15.51,3.242 15.67,3.198C16.413,2.993 17.867,3.231 18.814,4.1C19.752,4.959 20.182,6.141 20.33,6.902C20.387,7.197 20.251,7.499 19.96,7.571C19.099,7.785 17.524,7.494 16.534,6.587Z"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.182,20C6.02,20 3.955,18.705 3.391,16.795"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF617B"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12.227,11.579C11.277,10.395 9.818,9.636 8.182,9.636C5.718,9.636 3.477,11.579 3,13.932"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M16.408,2.476C16.241,2.326 15.525,2.045 14,2.125L15.079,4.458L16.408,2.476Z"
+      android:fillColor="#1B1D1F"/>
+  <path
+      android:pathData="M21,16.25C21,19.112 18.68,21.432 15.818,21.432C15.475,21.432 15.14,21.399 14.815,21.335C12.433,20.868 10.637,18.769 10.637,16.25C10.637,13.388 12.957,11.068 15.818,11.068C18.378,11.068 20.504,12.924 20.925,15.364C20.974,15.652 21,15.948 21,16.25Z"
+      android:strokeWidth="1.7"
+      android:fillColor="#00000000"
+      android:strokeColor="#1B1D1F"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #11 

## Work Description ✏️
 - 바텀 네비게이션의 디자인을 반영했습니다.

## Screenshot 📸
|                스크린샷                |
|:----------------------------------:|
| <img width="406" height="107" alt="image" src="https://github.com/user-attachments/assets/1a9bee82-d55d-4a2c-b22d-041dd145a252" /> |
<!-- <img width="360" src="이미지 주소" /> -->


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 그냥 더미로 넣어두었던 바텀 네비 디자인 반영해서 구현했어요 ~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메인 네비게이션 아이콘 추가 및 교체 (홈, 캘린더, 챌린지, 마이페이지)

* **개선사항**
  * 하단 네비게이션 바 레이아웃 및 스타일 개선
  * 탭 선택 비주얼(아이콘·텍스트 색상) 및 클릭 피드백 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->