### PR TITLE
[FEAT/#8] 선택 공통 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelction.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelction.kt
@@ -43,9 +43,9 @@ fun CherrishBasicChip(
     Row(
         modifier = modifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(9.dp))
+            .clip(shape = RoundedCornerShape(size = 9.dp))
             .background(backgroundColor)
-            .border(width = 1.dp, color = lineColor, shape = RoundedCornerShape(10.dp))
+            .border(width = 1.dp, color = lineColor, shape = RoundedCornerShape(size = 10.dp))
             .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -59,7 +59,7 @@ fun CherrishBasicChip(
 private fun CherrishSelectionChipPreview() {
     CherrishTheme {
         val cherrishColor = CherrishTheme.colors
-        var selected by remember { mutableStateOf(false) }
+        var selected by remember { mutableStateOf(value = false) }
         val textColor = if (selected) cherrishColor.gray800 else cherrishColor.gray700
 
         Column(
@@ -70,24 +70,25 @@ private fun CherrishSelectionChipPreview() {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-
             CherrishBasicChip(
                 selected = selected,
-                onClick = { selected = !selected },
-            ) { Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 12.dp),
-                contentAlignment = Alignment.Center
-            ){
-                Text(
-                    text = "여드름 ∙ 트러블",
-                    fontSize = 20.sp,
-                    style = CherrishTheme.typography.body1M14,
-                    color = textColor,
+                onClick = { selected = !selected }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "여드름 ∙ 트러블",
+                        fontSize = 20.sp,
+                        style = CherrishTheme.typography.body1M14,
+                        color = textColor,
 
-                    textAlign = TextAlign.Center
-                )}
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         }
     }
@@ -98,7 +99,7 @@ private fun CherrishSelectionChipPreview() {
 private fun CherrishMissionCardPreview() {
     CherrishTheme {
         val cherrishColor = CherrishTheme.colors
-        var selected by remember { mutableStateOf(false) }
+        var selected by remember { mutableStateOf(value = false) }
         val textColor = if (selected) cherrishColor.gray800 else cherrishColor.gray700
 
         val lineColor = if (selected) cherrishColor.red500 else cherrishColor.gray500
@@ -118,32 +119,33 @@ private fun CherrishMissionCardPreview() {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(10.dp)
+                        .padding(all = 10.dp)
                 ) {
                     Text(
                         text = "반신욕 20분",
                         style = CherrishTheme.typography.body1M14,
                         color = textColor,
-                        modifier = Modifier.align(Alignment.BottomStart), fontSize = 15.sp,
+                        modifier = Modifier.align(Alignment.BottomStart),
+                        fontSize = 15.sp
                     )
 
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
-                            .size(18.dp)
-                            .clip(RoundedCornerShape(50))
+                            .size(size = 18.dp)
+                            .clip(shape = RoundedCornerShape(percent = 50))
                             .border(
                                 width = 1.dp,
                                 color = lineColor,
-                                shape = RoundedCornerShape(50)
+                                shape = RoundedCornerShape(percent = 50)
                             ),
                         contentAlignment = Alignment.Center
                     ) {
                         if (selected) {
                             Box(
                                 modifier = Modifier
-                                    .size(8.dp)
-                                    .clip(RoundedCornerShape(50))
+                                    .size(size = 8.dp)
+                                    .clip(shape = RoundedCornerShape(percent = 50))
                                     .background(indicatorColor)
                             )
                         }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelction.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelction.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +24,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
@@ -38,8 +41,9 @@ fun CherrishBasicChip(
     val lineColor = if (selected) cherrishColor.red500 else cherrishColor.gray500
 
     Row(
-        modifier = modifier.fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
+        modifier = modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(9.dp))
             .background(backgroundColor)
             .border(width = 1.dp, color = lineColor, shape = RoundedCornerShape(10.dp))
             .clickable(onClick = onClick)
@@ -52,7 +56,7 @@ fun CherrishBasicChip(
 
 @Preview
 @Composable
-private fun CherrishBasicChipPreview() {
+private fun CherrishSelectionChipPreview() {
     CherrishTheme {
         val cherrishColor = CherrishTheme.colors
         var selected by remember { mutableStateOf(false) }
@@ -60,25 +64,91 @@ private fun CherrishBasicChipPreview() {
 
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .background(color = CherrishTheme.colors.gray0)
-                .padding(50.dp),
+                .padding(vertical = 300.dp, horizontal = 80.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Box(Modifier.padding(20.dp))
 
             CherrishBasicChip(
                 selected = selected,
-                onClick = { selected = !selected }
-            ) {
+                onClick = { selected = !selected },
+            ) { Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp),
+                contentAlignment = Alignment.Center
+            ){
                 Text(
-                    text = "여드름 . 트러블",
+                    text = "여드름 ∙ 트러블",
+                    fontSize = 20.sp,
                     style = CherrishTheme.typography.body1M14,
                     color = textColor,
-                    modifier = Modifier.fillMaxWidth(),
+
                     textAlign = TextAlign.Center
-                )
+                )}
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CherrishMissionCardPreview() {
+    CherrishTheme {
+        val cherrishColor = CherrishTheme.colors
+        var selected by remember { mutableStateOf(false) }
+        val textColor = if (selected) cherrishColor.gray800 else cherrishColor.gray700
+
+        val lineColor = if (selected) cherrishColor.red500 else cherrishColor.gray500
+        val indicatorColor = if (selected) cherrishColor.red700 else cherrishColor.gray500
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 300.dp, horizontal = 80.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            CherrishBasicChip(
+                selected = selected,
+                onClick = { selected = !selected },
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(10.dp)
+                ) {
+                    Text(
+                        text = "반신욕 20분",
+                        style = CherrishTheme.typography.body1M14,
+                        color = textColor,
+                        modifier = Modifier.align(Alignment.BottomStart), fontSize = 15.sp,
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .size(18.dp)
+                            .clip(RoundedCornerShape(50))
+                            .border(
+                                width = 1.dp,
+                                color = lineColor,
+                                shape = RoundedCornerShape(50)
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (selected) {
+                            Box(
+                                modifier = Modifier
+                                    .size(8.dp)
+                                    .clip(RoundedCornerShape(50))
+                                    .background(indicatorColor)
+                            )
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelction.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelction.kt
@@ -1,0 +1,85 @@
+package com.cherrish.android.core.designsystem.component.chip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun CherrishBasicChip(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    selected: Boolean,
+    content: @Composable () -> Unit
+) {
+    val cherrishColor = CherrishTheme.colors
+
+    val backgroundColor = if (selected) cherrishColor.red200 else cherrishColor.gray0
+
+    val lineColor = if (selected) cherrishColor.red500 else cherrishColor.gray500
+
+    Row(
+        modifier = modifier.fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(backgroundColor)
+            .border(width = 1.dp, color = lineColor, shape = RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        content()
+    }
+}
+
+@Preview
+@Composable
+private fun CherrishBasicChipPreview() {
+    CherrishTheme {
+        val cherrishColor = CherrishTheme.colors
+        var selected by remember { mutableStateOf(false) }
+        val textColor = if (selected) cherrishColor.gray800 else cherrishColor.gray700
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = CherrishTheme.colors.gray0)
+                .padding(50.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(Modifier.padding(20.dp))
+
+            CherrishBasicChip(
+                selected = selected,
+                onClick = { selected = !selected }
+            ) {
+                Text(
+                    text = "여드름 . 트러블",
+                    style = CherrishTheme.typography.body1M14,
+                    color = textColor,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -2,12 +2,9 @@ package com.cherrish.android.core.designsystem.component.chip
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -24,7 +21,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.cherrish.android.core.common.extension.noRippleClickable
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
@@ -32,9 +28,8 @@ import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 @Composable
 fun CherrishSelectionChip(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     selected: Boolean,
-
+    modifier: Modifier = Modifier,
     style: CherrishSelectionChipStyle = CherrishSelectionChipStyle.SELECTIONCHIP,
     content: @Composable () -> Unit
 ) {
@@ -68,9 +63,11 @@ fun CherrishSelectionChip(
         CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
     }
 
-    Row(
+
+    Column(
+
         modifier = modifier
-            .fillMaxSize()
+            .fillMaxWidth()
             .clip(shape = RoundedCornerShape(size = cornerRadius))
             .background(backgroundColor)
             .border(
@@ -80,7 +77,9 @@ fun CherrishSelectionChip(
             )
             .noRippleClickable(onClick = onClick)
             .padding(paddingValues),
-        verticalAlignment = Alignment.CenterVertically
+
+        horizontalAlignment = Alignment.CenterHorizontally
+
     ) {
         content()
     }
@@ -89,38 +88,25 @@ fun CherrishSelectionChip(
 @Preview
 @Composable
 private fun CherrishSelectionChipPreview() {
+
     CherrishTheme {
         var selected by remember { mutableStateOf(value = false) }
         val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
-        Column(
+        CherrishSelectionChip(
+            selected = selected,
+            onClick = { selected = !selected },
+            style = CherrishSelectionChipStyle.SELECTIONCHIP,
             modifier = Modifier
-                .fillMaxSize()
-                .background(color = CherrishTheme.colors.gray0)
-                .padding(vertical = 300.dp, horizontal = 80.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+                .fillMaxWidth()
+                .padding(60.dp)
         ) {
-            CherrishSelectionChip(
-                selected = selected,
-                onClick = { selected = !selected }
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 12.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "여드름 ∙ 트러블",
-                        fontSize = 20.sp,
-                        style = CherrishTheme.typography.body1M14,
-                        color = textColor,
-
-                        textAlign = TextAlign.Center
-                    )
-                }
-            }
+            Text(
+                text = "여드름 ∙ 트러블",
+                color = textColor,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }
@@ -130,56 +116,47 @@ private fun CherrishSelectionChipPreview() {
 private fun CherrishMissionCardPreview() {
     CherrishTheme {
         var selected by remember { mutableStateOf(value = false) }
+
         val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
-
         val lineColor = if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
-        val indicatorColor =
-            if (selected) CherrishTheme.colors.red700 else CherrishTheme.colors.gray500
+        val indicatorColor = if (selected) CherrishTheme.colors.red700 else CherrishTheme.colors.gray500
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(vertical = 300.dp, horizontal = 80.dp),
-            contentAlignment = Alignment.Center
+        CherrishSelectionChip(
+            selected = selected,
+            onClick = { selected = !selected },
+            modifier = Modifier.fillMaxWidth(),
+            style = CherrishSelectionChipStyle.MISSIONCARD
         ) {
-            CherrishSelectionChip(
-                selected = selected,
-                onClick = { selected = !selected },
-                modifier = Modifier.fillMaxSize()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(all = 10.dp)
             ) {
+                Text(
+                    text = "반신욕 20분",
+                    color = textColor,
+                    modifier = Modifier.align(Alignment.BottomStart)
+                )
+
                 Box(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .padding(all = 10.dp)
+                        .align(Alignment.TopEnd)
+                        .size(size = 18.dp)
+                        .clip(shape = RoundedCornerShape(size = 10.dp))
+                        .border(
+                            width = 1.dp,
+                            color = lineColor,
+                            shape = RoundedCornerShape(size = 10.dp)
+                        ),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Text(
-                        text = "반신욕 20분",
-                        style = CherrishTheme.typography.body1M14,
-                        color = textColor,
-                        modifier = Modifier.align(Alignment.BottomStart),
-                        fontSize = 15.sp
-                    )
-
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .size(size = 18.dp)
-                            .clip(shape = RoundedCornerShape(percent = 50))
-                            .border(
-                                width = 1.dp,
-                                color = lineColor,
-                                shape = RoundedCornerShape(percent = 50)
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (selected) {
-                            Box(
-                                modifier = Modifier
-                                    .size(size = 8.dp)
-                                    .clip(shape = RoundedCornerShape(percent = 50))
-                                    .background(indicatorColor)
-                            )
-                        }
+                    if (selected) {
+                        Box(
+                            modifier = Modifier
+                                .size(size = 8.dp)
+                                .clip(shape = RoundedCornerShape(size = 10.dp))
+                                .background(indicatorColor)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cherrish.android.core.common.extension.noRippleClickable
@@ -27,30 +28,23 @@ import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 @Composable
 fun CherrishSelectionChip(
     onClick: () -> Unit,
-    selected: Boolean,
+
     modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
     style: CherrishSelectionChipStyle = CherrishSelectionChipStyle.SELECTIONCHIP,
     content: @Composable () -> Unit
 ) {
     val backgroundColor = when (style) {
         CherrishSelectionChipStyle.SELECTIONCHIP -> {
-            if (selected) CherrishTheme.colors.red200 else CherrishTheme.colors.gray0
+            if (isSelected) CherrishTheme.colors.red200 else CherrishTheme.colors.gray0
         }
 
         CherrishSelectionChipStyle.MISSIONCARD -> {
-            if (selected) CherrishTheme.colors.red100 else CherrishTheme.colors.gray0
+            if (isSelected) CherrishTheme.colors.red100 else CherrishTheme.colors.gray0
         }
     }
 
-    val lineColor = when (style) {
-        CherrishSelectionChipStyle.SELECTIONCHIP -> {
-            if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
-        }
-
-        CherrishSelectionChipStyle.MISSIONCARD -> {
-            if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
-        }
-    }
+    val lineColor = if (isSelected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
 
     val cornerRadius = when (style) {
         CherrishSelectionChipStyle.SELECTIONCHIP -> 10.dp
@@ -60,7 +54,7 @@ fun CherrishSelectionChip(
     val paddingValues = when (style) {
         CherrishSelectionChipStyle.SELECTIONCHIP -> PaddingValues(10.dp)
         CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
-    }
+    } // 최소일떄 패딩
 
     Column(
         modifier = modifier
@@ -91,17 +85,19 @@ private fun CherrishSelectionChipPreview() {
         CherrishSelectionChip(
 
             onClick = { selected = !selected },
-            selected = selected,
+            isSelected = selected,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(60.dp),
+                .padding(all = 60.dp),
             style = CherrishSelectionChipStyle.SELECTIONCHIP
 
         ) {
             Text(
                 text = "여드름 ∙ 트러블",
-                modifier = Modifier.fillMaxWidth(),
-                color = textColor
+                modifier = Modifier.fillMaxWidth().padding(vertical = 40.dp),
+                color = textColor,
+                textAlign = TextAlign.Center
+
             )
         }
     }
@@ -120,7 +116,7 @@ private fun CherrishMissionCardPreview() {
 
         CherrishSelectionChip(
             onClick = { selected = !selected },
-            selected = selected,
+            isSelected = selected,
             modifier = Modifier.fillMaxWidth(),
             style = CherrishSelectionChipStyle.MISSIONCARD
         ) {

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -31,7 +31,7 @@ import com.cherrish.android.core.designsystem.theme.red700
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 
 @Composable
-fun CherrishSelectionChip(
+fun CherrishSelectionBaseChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
@@ -60,6 +60,7 @@ fun CherrishSelectionChip(
             horizontal = 10.dp,
             vertical = 30.dp
         )
+
         CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
     }
 
@@ -81,33 +82,97 @@ fun CherrishSelectionChip(
     }
 }
 
+@Composable
+fun CherrishSelectionChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
+
+    CherrishSelectionBaseChip(
+        onClick = onClick,
+        modifier = modifier,
+        isSelected = selected,
+        style = CherrishSelectionChipStyle.SELECTIONCHIP
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 40.dp),
+            color = textColor,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+fun CherrishMissionCardChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val textColor =
+        if (selected) {
+            CherrishTheme.colors.gray800
+        } else {
+            CherrishTheme.colors.gray700
+        }
+
+    CherrishSelectionBaseChip(
+        onClick = onClick,
+        modifier = modifier,
+        isSelected = selected,
+        style = CherrishSelectionChipStyle.MISSIONCARD
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = text,
+                color = textColor,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(
+                        start = 7.dp,
+                        top = 38.dp,
+                        bottom = 6.dp
+                    )
+            )
+
+            Icon(
+                imageVector = ImageVector.vectorResource(
+                    id = if (selected) {
+                        R.drawable.ic_radiobtn_selected
+                    } else {
+                        R.drawable.ic_radiobtn_default
+                    }
+                ),
+                tint = if (selected) red700 else gray500,
+                contentDescription = null,
+                modifier = Modifier.align(Alignment.TopEnd)
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 private fun CherrishSelectionChipPreview() {
     CherrishTheme {
         var selected by remember { mutableStateOf(value = false) }
-        val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
         CherrishSelectionChip(
-
+            text = "여드름 ∙ 트러블",
+            selected = selected,
             onClick = { selected = !selected },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = 60.dp),
-            isSelected = selected,
-            style = CherrishSelectionChipStyle.SELECTIONCHIP
-
-        ) {
-            Text(
-                text = "여드름 ∙ 트러블",
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 40.dp),
-                color = textColor,
-                textAlign = TextAlign.Center
-
-            )
-        }
+                .padding(60.dp)
+        )
     }
 }
 
@@ -117,45 +182,13 @@ private fun CherrishMissionCardPreview() {
     CherrishTheme {
         var selected by remember { mutableStateOf(value = false) }
 
-        val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
-
-        CherrishSelectionChip(
+        CherrishMissionCardChip(
+            text = "반신욕 20분",
+            selected = selected,
             onClick = { selected = !selected },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = 30.dp),
-            isSelected = selected,
-            style = CherrishSelectionChipStyle.MISSIONCARD
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-
-            ) {
-                Text(
-                    text = "반신욕 20분",
-                    modifier = Modifier.align(Alignment.BottomStart).padding(
-                        start = 7.dp,
-                        bottom = 6.dp,
-                        top = 38.dp
-                    ),
-                    color = textColor
-
-                )
-
-                Icon(
-                    imageVector = ImageVector.vectorResource(
-                        id = if (selected) {
-                            R.drawable.ic_radiobtn_selected
-                        } else {
-                            R.drawable.ic_radiobtn_default
-                        }
-                    ),
-                    tint = if (selected) red700 else gray500,
-                    contentDescription = null,
-                    modifier = Modifier.align(Alignment.TopEnd)
-                )
-            }
-        }
+                .padding(30.dp)
+        )
     }
 }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -57,7 +58,9 @@ fun CherrishSelectionChip(
     val paddingValues = when (style) {
         CherrishSelectionChipStyle.SELECTIONCHIP -> PaddingValues(10.dp)
         CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
-    } // 최소일떄 패딩
+    }
+
+    // 최소일떄 패딩
 
     Column(
         modifier = modifier
@@ -72,7 +75,6 @@ fun CherrishSelectionChip(
             .noRippleClickable(onClick = onClick)
             .padding(paddingValues),
 
-        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         content()
     }
@@ -129,7 +131,11 @@ private fun CherrishMissionCardPreview() {
             ) {
                 Text(
                     text = "반신욕 20분",
-                    modifier = Modifier.align(Alignment.BottomStart).padding(vertical = 50.dp),
+                    modifier = Modifier.align(Alignment.BottomStart).padding(
+                        start = 7.dp,
+                        bottom = 6.dp,
+                        top = 38.dp
+                    ),
                     color = textColor
 
                 )

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -73,7 +72,7 @@ fun CherrishSelectionChip(
                 shape = RoundedCornerShape(size = cornerRadius)
             )
             .noRippleClickable(onClick = onClick)
-            .padding(paddingValues),
+            .padding(paddingValues)
 
     ) {
         content()
@@ -142,10 +141,11 @@ private fun CherrishMissionCardPreview() {
 
                 Image(
                     painter = painterResource(
-                        id = if (selected)
+                        id = if (selected) {
                             R.drawable.ic_radiobtn_selected
-                        else
+                        } else {
                             R.drawable.ic_radiobtn_default
+                        }
                     ),
                     contentDescription = null,
                     modifier = Modifier.align(Alignment.TopEnd)

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cherrish.android.core.common.extension.noRippleClickable
@@ -63,9 +62,7 @@ fun CherrishSelectionChip(
         CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
     }
 
-
     Column(
-
         modifier = modifier
             .fillMaxWidth()
             .clip(shape = RoundedCornerShape(size = cornerRadius))
@@ -79,7 +76,6 @@ fun CherrishSelectionChip(
             .padding(paddingValues),
 
         horizontalAlignment = Alignment.CenterHorizontally
-
     ) {
         content()
     }
@@ -88,24 +84,24 @@ fun CherrishSelectionChip(
 @Preview
 @Composable
 private fun CherrishSelectionChipPreview() {
-
     CherrishTheme {
         var selected by remember { mutableStateOf(value = false) }
         val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
         CherrishSelectionChip(
-            selected = selected,
+
             onClick = { selected = !selected },
-            style = CherrishSelectionChipStyle.SELECTIONCHIP,
+            selected = selected,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(60.dp)
+                .padding(60.dp),
+            style = CherrishSelectionChipStyle.SELECTIONCHIP
+
         ) {
             Text(
                 text = "여드름 ∙ 트러블",
-                color = textColor,
                 modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center
+                color = textColor
             )
         }
     }
@@ -119,11 +115,12 @@ private fun CherrishMissionCardPreview() {
 
         val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
         val lineColor = if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
-        val indicatorColor = if (selected) CherrishTheme.colors.red700 else CherrishTheme.colors.gray500
+        val indicatorColor =
+            if (selected) CherrishTheme.colors.red700 else CherrishTheme.colors.gray500
 
         CherrishSelectionChip(
-            selected = selected,
             onClick = { selected = !selected },
+            selected = selected,
             modifier = Modifier.fillMaxWidth(),
             style = CherrishSelectionChipStyle.MISSIONCARD
         ) {
@@ -134,8 +131,9 @@ private fun CherrishMissionCardPreview() {
             ) {
                 Text(
                     text = "반신욕 20분",
-                    color = textColor,
-                    modifier = Modifier.align(Alignment.BottomStart)
+                    modifier = Modifier.align(Alignment.BottomStart),
+                    color = textColor
+
                 )
 
                 Box(

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -2,10 +2,10 @@ package com.cherrish.android.core.designsystem.component.chip
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,29 +25,61 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cherrish.android.core.common.extension.noRippleClickable
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 
 @Composable
-fun CherrishBasicChip(
+fun CherrishSelectionChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     selected: Boolean,
+
+    style: CherrishSelectionChipStyle = CherrishSelectionChipStyle.SELECTIONCHIP,
     content: @Composable () -> Unit
 ) {
-    val cherrishColor = CherrishTheme.colors
+    val backgroundColor = when (style) {
+        CherrishSelectionChipStyle.SELECTIONCHIP -> {
+            if (selected) CherrishTheme.colors.red200 else CherrishTheme.colors.gray0
+        }
 
-    val backgroundColor = if (selected) cherrishColor.red200 else cherrishColor.gray0
+        CherrishSelectionChipStyle.MISSIONCARD -> {
+            if (selected) CherrishTheme.colors.red100 else CherrishTheme.colors.gray0
+        }
+    }
 
-    val lineColor = if (selected) cherrishColor.red500 else cherrishColor.gray500
+    val lineColor = when (style) {
+        CherrishSelectionChipStyle.SELECTIONCHIP -> {
+            if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
+        }
+
+        CherrishSelectionChipStyle.MISSIONCARD -> {
+            if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
+        }
+    }
+
+    val cornerRadius = when (style) {
+        CherrishSelectionChipStyle.SELECTIONCHIP -> 10.dp
+        CherrishSelectionChipStyle.MISSIONCARD -> 9.dp
+    }
+
+    val paddingValues = when (style) {
+        CherrishSelectionChipStyle.SELECTIONCHIP -> PaddingValues(10.dp)
+        CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
+    }
 
     Row(
         modifier = modifier
             .fillMaxSize()
-            .clip(shape = RoundedCornerShape(size = 9.dp))
+            .clip(shape = RoundedCornerShape(size = cornerRadius))
             .background(backgroundColor)
-            .border(width = 1.dp, color = lineColor, shape = RoundedCornerShape(size = 10.dp))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .border(
+                width = 1.dp,
+                color = lineColor,
+                shape = RoundedCornerShape(size = cornerRadius)
+            )
+            .noRippleClickable(onClick = onClick)
+            .padding(paddingValues),
         verticalAlignment = Alignment.CenterVertically
     ) {
         content()
@@ -58,9 +90,8 @@ fun CherrishBasicChip(
 @Composable
 private fun CherrishSelectionChipPreview() {
     CherrishTheme {
-        val cherrishColor = CherrishTheme.colors
         var selected by remember { mutableStateOf(value = false) }
-        val textColor = if (selected) cherrishColor.gray800 else cherrishColor.gray700
+        val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
         Column(
             modifier = Modifier
@@ -70,7 +101,7 @@ private fun CherrishSelectionChipPreview() {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CherrishBasicChip(
+            CherrishSelectionChip(
                 selected = selected,
                 onClick = { selected = !selected }
             ) {
@@ -98,12 +129,12 @@ private fun CherrishSelectionChipPreview() {
 @Composable
 private fun CherrishMissionCardPreview() {
     CherrishTheme {
-        val cherrishColor = CherrishTheme.colors
         var selected by remember { mutableStateOf(value = false) }
-        val textColor = if (selected) cherrishColor.gray800 else cherrishColor.gray700
+        val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
-        val lineColor = if (selected) cherrishColor.red500 else cherrishColor.gray500
-        val indicatorColor = if (selected) cherrishColor.red700 else cherrishColor.gray500
+        val lineColor = if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
+        val indicatorColor =
+            if (selected) CherrishTheme.colors.red700 else CherrishTheme.colors.gray500
 
         Box(
             modifier = Modifier
@@ -111,7 +142,7 @@ private fun CherrishMissionCardPreview() {
                 .padding(vertical = 300.dp, horizontal = 80.dp),
             contentAlignment = Alignment.Center
         ) {
-            CherrishBasicChip(
+            CherrishSelectionChip(
                 selected = selected,
                 onClick = { selected = !selected },
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -1,5 +1,7 @@
 package com.cherrish.android.core.designsystem.component.chip
 
+import android.media.Image
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -18,9 +20,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.cherrish.android.R
 import com.cherrish.android.core.common.extension.noRippleClickable
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
@@ -28,7 +32,6 @@ import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 @Composable
 fun CherrishSelectionChip(
     onClick: () -> Unit,
-
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
     style: CherrishSelectionChipStyle = CherrishSelectionChipStyle.SELECTIONCHIP,
@@ -85,16 +88,18 @@ private fun CherrishSelectionChipPreview() {
         CherrishSelectionChip(
 
             onClick = { selected = !selected },
-            isSelected = selected,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(all = 60.dp),
+            isSelected = selected,
             style = CherrishSelectionChipStyle.SELECTIONCHIP
 
         ) {
             Text(
                 text = "여드름 ∙ 트러블",
-                modifier = Modifier.fillMaxWidth().padding(vertical = 40.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 40.dp),
                 color = textColor,
                 textAlign = TextAlign.Center
 
@@ -110,49 +115,35 @@ private fun CherrishMissionCardPreview() {
         var selected by remember { mutableStateOf(value = false) }
 
         val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
-        val lineColor = if (selected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
-        val indicatorColor =
-            if (selected) CherrishTheme.colors.red700 else CherrishTheme.colors.gray500
 
         CherrishSelectionChip(
             onClick = { selected = !selected },
+            modifier = Modifier.fillMaxWidth().padding(all = 30.dp),
             isSelected = selected,
-            modifier = Modifier.fillMaxWidth(),
             style = CherrishSelectionChipStyle.MISSIONCARD
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(all = 10.dp)
+
             ) {
                 Text(
                     text = "반신욕 20분",
-                    modifier = Modifier.align(Alignment.BottomStart),
+                    modifier = Modifier.align(Alignment.BottomStart).padding(vertical = 50.dp),
                     color = textColor
 
                 )
 
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .size(size = 18.dp)
-                        .clip(shape = RoundedCornerShape(size = 10.dp))
-                        .border(
-                            width = 1.dp,
-                            color = lineColor,
-                            shape = RoundedCornerShape(size = 10.dp)
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (selected) {
-                        Box(
-                            modifier = Modifier
-                                .size(size = 8.dp)
-                                .clip(shape = RoundedCornerShape(size = 10.dp))
-                                .background(indicatorColor)
-                        )
-                    }
-                }
+                Image(
+                    painter = painterResource(
+                        id = if (selected)
+                            R.drawable.ic_radiobtn_selected
+                        else
+                            R.drawable.ic_radiobtn_default
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier.align(Alignment.TopEnd)
+                )
             }
         }
     }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -1,7 +1,5 @@
 package com.cherrish.android.core.designsystem.component.chip
 
-import android.media.Image
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -9,8 +7,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,13 +18,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cherrish.android.R
 import com.cherrish.android.core.common.extension.noRippleClickable
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.core.designsystem.theme.gray500
+import com.cherrish.android.core.designsystem.theme.red700
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 
 @Composable
@@ -55,11 +56,12 @@ fun CherrishSelectionChip(
     }
 
     val paddingValues = when (style) {
-        CherrishSelectionChipStyle.SELECTIONCHIP -> PaddingValues(10.dp)
+        CherrishSelectionChipStyle.SELECTIONCHIP -> PaddingValues(
+            horizontal = 10.dp,
+            vertical = 30.dp
+        )
         CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
     }
-
-    // 최소일떄 패딩
 
     Column(
         modifier = modifier
@@ -119,7 +121,9 @@ private fun CherrishMissionCardPreview() {
 
         CherrishSelectionChip(
             onClick = { selected = !selected },
-            modifier = Modifier.fillMaxWidth().padding(all = 30.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = 30.dp),
             isSelected = selected,
             style = CherrishSelectionChipStyle.MISSIONCARD
         ) {
@@ -139,14 +143,15 @@ private fun CherrishMissionCardPreview() {
 
                 )
 
-                Image(
-                    painter = painterResource(
+                Icon(
+                    imageVector = ImageVector.vectorResource(
                         id = if (selected) {
                             R.drawable.ic_radiobtn_selected
                         } else {
                             R.drawable.ic_radiobtn_default
                         }
                     ),
+                    tint = if (selected) red700 else gray500,
                     contentDescription = null,
                     modifier = Modifier.align(Alignment.TopEnd)
                 )

--- a/app/src/main/java/com/cherrish/android/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/theme/Type.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.cherrish.android.R
@@ -17,6 +19,22 @@ val cherrishFontBold = FontFamily(Font(R.font.pretendard_bold))
 val cherrishFontSemiBold = FontFamily(Font(R.font.pretendard_semibold))
 val cherrishFontMedium = FontFamily(Font(R.font.pretendard_medium))
 val cherrishFontRegular = FontFamily(Font(R.font.pretendard_regular))
+
+private fun CherrishTextStyle(
+    fontFamily: FontFamily,
+    fontSize: TextUnit,
+    letterSpacing: TextUnit = 0.em,
+    lineHeight: TextUnit
+): TextStyle = TextStyle(
+    fontFamily = fontFamily,
+    fontSize = fontSize,
+    letterSpacing = letterSpacing,
+    lineHeight = lineHeight,
+    lineHeightStyle = LineHeightStyle(
+        alignment = LineHeightStyle.Alignment.Center,
+        trim = LineHeightStyle.Trim.None
+    )
+)
 
 @Immutable
 data class CherrishTypography(
@@ -47,81 +65,98 @@ data class CherrishTypography(
 
 val defaultCherrishTypography = CherrishTypography(
 
-    headlineB20 = TextStyle(
+    headlineB20 = CherrishTextStyle(
         fontFamily = cherrishFontBold,
         fontSize = 20.sp,
-        letterSpacing = 0.01.em
+        letterSpacing = 0.01.em,
+        lineHeight = 1.5.em
     ),
-    headlineSB20 = TextStyle(
+
+    headlineSB20 = CherrishTextStyle(
         fontFamily = cherrishFontSemiBold,
         fontSize = 20.sp,
-        letterSpacing = 0.01.em
+        letterSpacing = 0.01.em,
+        lineHeight = 1.5.em
+
     ),
 
-    title1SB18 = TextStyle(
+    title1SB18 = CherrishTextStyle(
         fontFamily = cherrishFontSemiBold,
         fontSize = 18.sp,
-        letterSpacing = 0.01.em
+        letterSpacing = 0.01.em,
+        lineHeight = 1.5.em
     ),
-    title1M18 = TextStyle(
+    title1M18 = CherrishTextStyle(
         fontFamily = cherrishFontMedium,
         fontSize = 18.sp,
-        letterSpacing = 0.01.em
+        letterSpacing = 0.01.em,
+        lineHeight = 1.5.em
     ),
-    title1R18 = TextStyle(
+    title1R18 = CherrishTextStyle(
         fontFamily = cherrishFontRegular,
         fontSize = 18.sp,
-        letterSpacing = 0.01.em
+        letterSpacing = 0.01.em,
+        lineHeight = 1.5.em
     ),
 
-    title2SB16 = TextStyle(
+    title2SB16 = CherrishTextStyle(
         fontFamily = cherrishFontSemiBold,
-        fontSize = 16.sp
+        fontSize = 16.sp,
+        lineHeight = 1.5.em
     ),
 
-    title2M16 = TextStyle(
+    title2M16 = CherrishTextStyle(
         fontFamily = cherrishFontMedium,
-        fontSize = 16.sp
+        fontSize = 16.sp,
+        lineHeight = 1.5.em
     ),
 
-    title2R16 = TextStyle(
+    title2R16 = CherrishTextStyle(
         fontFamily = cherrishFontRegular,
-        fontSize = 16.sp
+        fontSize = 16.sp,
+        lineHeight = 1.5.em
     ),
 
-    body1SB14 = TextStyle(
+    body1SB14 = CherrishTextStyle(
         fontFamily = cherrishFontSemiBold,
-        fontSize = 14.sp
+        fontSize = 14.sp,
+        lineHeight = 1.4.em
     ),
 
-    body1M14 = TextStyle(
+    body1M14 = CherrishTextStyle(
         fontFamily = cherrishFontMedium,
-        fontSize = 14.sp
+        fontSize = 14.sp,
+        lineHeight = 1.4.em
     ),
 
-    body1R14 = TextStyle(
+    body1R14 = CherrishTextStyle(
         fontFamily = cherrishFontRegular,
-        fontSize = 14.sp
+        fontSize = 14.sp,
+        lineHeight = 1.4.em
     ),
 
-    body2R13 = TextStyle(
+    body2R13 = CherrishTextStyle(
         fontFamily = cherrishFontRegular,
-        fontSize = 13.sp
+        fontSize = 13.sp,
+        lineHeight = 1.4.em
     ),
 
-    body3M12 = TextStyle(
+    body3M12 = CherrishTextStyle(
         fontFamily = cherrishFontMedium,
-        fontSize = 12.sp
+        fontSize = 12.sp,
+        lineHeight = 1.4.em
     ),
 
-    body3R12 = TextStyle(
+    body3R12 = CherrishTextStyle(
         fontFamily = cherrishFontRegular,
-        fontSize = 12.sp
+        fontSize = 12.sp,
+        lineHeight = 1.4.em
     ),
 
-    captionR11 = TextStyle(
+    captionR11 = CherrishTextStyle(
         fontFamily = cherrishFontRegular,
-        fontSize = 11.sp
+        fontSize = 11.sp,
+        lineHeight = 1.4.em
     )
 
 )

--- a/app/src/main/java/com/cherrish/android/core/designsystem/type/CherrishSelectionChipStyle.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/type/CherrishSelectionChipStyle.kt
@@ -1,0 +1,6 @@
+package com.cherrish.android.core.designsystem.type
+
+enum class CherrishSelectionChipStyle {
+    SELECTIONCHIP,
+    MISSIONCARD
+}

--- a/app/src/main/res/drawable/ic_radiobtn_default.xml
+++ b/app/src/main/res/drawable/ic_radiobtn_default.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,12m-6.5,0a6.5,6.5 0,1 1,13 0a6.5,6.5 0,1 1,-13 0"
+      android:fillColor="#00000000"
+      android:strokeColor="#CACDD1"/>
+</vector>

--- a/app/src/main/res/drawable/ic_radiobtn_selected.xml
+++ b/app/src/main/res/drawable/ic_radiobtn_selected.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,12m-6.5,0a6.5,6.5 0,1 1,13 0a6.5,6.5 0,1 1,-13 0"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF617B"/>
+  <path
+      android:pathData="M12,12m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0"
+      android:fillColor="#FF617B"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #8 

## Work Description ✏️
 - 피그마 내에 있는 SelectionChip을 구현했습니다.
 - 선택/미선택에 따른 UI 변경을 반영했습니다.
 - `@Composable`을 함수 인자로 받아 사용할 수 있도록 구현했습니다. 
 - Preview를 만들었습니다. 


## Screenshot 📸
<details>
  <summary>SelectionBasicChip</summary>
   !(https://github.com/user-attachments/assets/87578200-ed63-42c8-9066-08ce9856312d)
</details>

<img width="725" height="411" alt="image" src="https://github.com/user-attachments/assets/d83c89b2-0b2f-4b33-8c9d-a753c5159895" />

<details>
  <summary><b> MissionChip</b></summary>
[  <!-- 내용 -->](https://github.com/user-attachments/assets/759aa4c6-2a73-4df1-b806-1c0fe03fb1c0)
</details>

<img width="178" height="100" alt="image" src="https://github.com/user-attachments/assets/79fb8c29-4e02-4a48-a4a8-2e2070a5e6f0" />

## Uncompleted Tasks 😅
- [x] N/A

## To Reviewers 📢
나현언니가 프리뷰를 만드는 것에 대해 친절히 알려줬는데 외부에서 패딩을 weight로 주는 것이 어려워서 현재는 상위 컴포저블에서 dp 값을 사용해 패딩을 적용했습니다... 😅 리뷰해주시면 감사하겠습니다 ㅜㅜ! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 선택 가능한 칩 컴포넌트 추가 — 기본 칩 및 미션 카드 스타일, 선택 토글과 클릭 동작, 미리보기 포함

* **스타일**
  * 타이포그래피 개선 — 정교한 라인 높이 적용으로 텍스트 가독성 향상

* **자산**
  * 라디오 버튼 아이콘 추가 — 선택/비선택 상태를 위한 벡터 아이콘 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->