### PR TITLE
[FEAT/#9] 게이지바 공통 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.Layout
@@ -47,7 +48,14 @@ fun CherrishGaugeBar(
                     key(gauge) {
                         val isActive = gauge.step <= currentStep
                         val isSelected = gauge.step == currentStep
-                        val gaugeStyle = gauge.style(isActive, isSelected)
+                        val cherrishColor = CherrishTheme.colors
+                        val gaugeStyle = remember(gauge, isActive, isSelected) {
+                            gauge.style(
+                                colors = cherrishColor,
+                                isActive = isActive,
+                                isSelected = isSelected
+                            )
+                        }
 
                         Column(
                             verticalArrangement = Arrangement.spacedBy(2.dp)

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
@@ -34,6 +34,8 @@ fun CherrishGaugeBar(
     BoxWithConstraints(
         modifier = modifier.fillMaxWidth()
     ) {
+        val reversedGauges = remember(gauges) { gauges.asReversed() }
+
         val baseSegmentWidth = 89.dp
         val baseSegmentOffset = 67.dp
         val totalBaseWidth = baseSegmentWidth + baseSegmentOffset * (gauges.size - 1)
@@ -44,7 +46,7 @@ fun CherrishGaugeBar(
 
         Layout(
             content = {
-                gauges.asReversed().forEach { gauge ->
+                reversedGauges.forEach { gauge ->
                     key(gauge) {
                         val isActive = gauge.step <= currentStep
                         val isSelected = gauge.step == currentStep
@@ -93,7 +95,7 @@ fun CherrishGaugeBar(
             val layoutHeight = segmentPlaceables.maxOfOrNull { it.height } ?: 0
 
             layout(width = constraints.maxWidth, height = layoutHeight) {
-                gauges.asReversed().forEachIndexed { i, gauge ->
+                reversedGauges.forEachIndexed { i, gauge ->
                     val originalIndex = gauge.step - 1
                     val xOffsetPx = (offsetWidth.toPx() * originalIndex).toInt()
 

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
@@ -1,6 +1,5 @@
 package com.cherrish.android.core.designsystem.component.gaugebar
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -25,7 +24,6 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
-@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun CherrishGaugeBar(
     currentStep: Int,
@@ -36,12 +34,12 @@ fun CherrishGaugeBar(
         modifier = modifier.fillMaxWidth()
     ) {
         val baseSegmentWidth = 89.dp
-        val baseSegmentOffest = 67.dp
-        val totalBaseWidth = baseSegmentWidth + baseSegmentOffest * (gauges.size - 1)
+        val baseSegmentOffset = 67.dp
+        val totalBaseWidth = baseSegmentWidth + baseSegmentOffset * (gauges.size - 1)
 
         val screenScale = maxWidth / totalBaseWidth
         val segmentWidth = baseSegmentWidth * screenScale
-        val offsetWidth = baseSegmentOffest * screenScale
+        val offsetWidth = baseSegmentOffset * screenScale
 
         Layout(
             content = {

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeBar.kt
@@ -1,0 +1,126 @@
+package com.cherrish.android.core.designsystem.component.gaugebar
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.component.type.CherrishGaugeType
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@Composable
+fun CherrishGaugeBar(
+    currentStep: Int,
+    gauges: ImmutableList<CherrishGaugeType>,
+    modifier: Modifier = Modifier
+) {
+    BoxWithConstraints(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        val baseSegmentWidth = 89.dp
+        val baseSegmentOffest = 67.dp
+        val totalBaseWidth = baseSegmentWidth + baseSegmentOffest * (gauges.size - 1)
+
+        val screenScale = maxWidth / totalBaseWidth
+        val segmentWidth = baseSegmentWidth * screenScale
+        val offsetWidth = baseSegmentOffest * screenScale
+
+        Layout(
+            content = {
+                gauges.asReversed().forEach { gauge ->
+                    key(gauge) {
+                        val isActive = gauge.step <= currentStep
+                        val isSelected = gauge.step == currentStep
+                        val gaugeStyle = gauge.style(isActive, isSelected)
+
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .width(segmentWidth)
+                                    .height(10.dp)
+                                    .clip(shape = RoundedCornerShape(10.dp))
+                                    .background(color = gaugeStyle.gaugeLevelColor)
+                                    .border(
+                                        width = 1.dp,
+                                        color = gaugeStyle.gaugeLevelBorderColor,
+                                        shape = RoundedCornerShape(10.dp)
+                                    )
+                            )
+
+                            Text(
+                                text = gaugeStyle.gaugeLabel,
+                                color = gaugeStyle.gaugeLabelColor,
+                                style = CherrishTheme.typography.captionR11,
+                                textAlign = TextAlign.End,
+                                modifier = Modifier.width(segmentWidth)
+                            )
+                        }
+                    }
+                }
+            }
+        ) { measurables, constraints ->
+
+            val segmentPlaceables = measurables.map { measurable ->
+                measurable.measure(constraints.copy(minWidth = 0))
+            }
+
+            val layoutHeight = segmentPlaceables.maxOfOrNull { it.height } ?: 0
+
+            layout(width = constraints.maxWidth, height = layoutHeight) {
+                gauges.asReversed().forEachIndexed { i, gauge ->
+                    val originalIndex = gauge.step - 1
+                    val xOffsetPx = (offsetWidth.toPx() * originalIndex).toInt()
+
+                    segmentPlaceables[i].placeRelative(x = xOffsetPx, y = 0)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun Preview() {
+    CherrishTheme {
+        Column {
+            CherrishGaugeBar(
+                currentStep = 1,
+                gauges = CherrishGaugeType.entries.toImmutableList()
+            )
+
+            CherrishGaugeBar(
+                currentStep = 2,
+                gauges = CherrishGaugeType.entries.toImmutableList()
+            )
+
+            CherrishGaugeBar(
+                currentStep = 3,
+                gauges = CherrishGaugeType.entries.toImmutableList()
+            )
+            CherrishGaugeBar(
+                currentStep = 4,
+                gauges = CherrishGaugeType.entries.toImmutableList()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeColors.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeColors.kt
@@ -1,0 +1,43 @@
+package com.cherrish.android.core.designsystem.component.gaugebar
+
+import androidx.compose.ui.graphics.Color
+import com.cherrish.android.core.designsystem.component.type.CherrishGaugeType
+import com.cherrish.android.core.designsystem.theme.CherrishColors
+
+data class CherrishGaugeColors(
+    val background: Color,
+    val border: Color
+)
+
+fun cherrishGaugeActiveColors(
+    gaugeType: CherrishGaugeType,
+    colors: CherrishColors
+): CherrishGaugeColors =
+    when (gaugeType) {
+        CherrishGaugeType.LEVEL1 -> CherrishGaugeColors(
+            background = colors.red300,
+            border = colors.red500
+        )
+
+        CherrishGaugeType.LEVEL2 -> CherrishGaugeColors(
+            background = colors.red400,
+            border = colors.red600
+        )
+
+        CherrishGaugeType.LEVEL3 -> CherrishGaugeColors(
+            background = colors.red500,
+            border = colors.red700
+        )
+
+        CherrishGaugeType.LEVEL4 -> CherrishGaugeColors(
+            background = colors.red600,
+            border = colors.red800
+        )
+    }
+
+fun cherrishGaugeInactiveColors(
+    colors: CherrishColors
+): CherrishGaugeColors = CherrishGaugeColors(
+    background = colors.gray300,
+    border = colors.gray500
+)

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeStyle.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeStyle.kt
@@ -1,0 +1,56 @@
+package com.cherrish.android.core.designsystem.component.gaugebar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.cherrish.android.core.designsystem.component.type.CherrishGaugeType
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+data class CherrishGaugeStyle(
+    val gaugeLabel: String,
+    val gaugeLabelColor: Color,
+    val gaugeLevelColor: Color,
+    val gaugeLevelBorderColor: Color
+)
+
+@Composable
+fun CherrishGaugeType.style(isActive: Boolean, isSelected: Boolean): CherrishGaugeStyle {
+    val gaugeActiveColor = when (this) {
+        CherrishGaugeType.LEVEL1 -> Pair(
+            CherrishTheme.colors.red300,
+            CherrishTheme.colors.red500
+        )
+
+        CherrishGaugeType.LEVEL2 -> Pair(
+            CherrishTheme.colors.red400,
+            CherrishTheme.colors.red600
+        )
+
+        CherrishGaugeType.LEVEL3 -> Pair(
+            CherrishTheme.colors.red500,
+            CherrishTheme.colors.red700
+        )
+
+        CherrishGaugeType.LEVEL4 -> Pair(
+            CherrishTheme.colors.red600,
+            CherrishTheme.colors.red800
+        )
+    }
+
+    val gaugeInactiveColor = Pair(
+        CherrishTheme.colors.gray300,
+        CherrishTheme.colors.gray500
+    )
+
+    val (gaugeLevelColor, gaugeLevelBorderColor) =
+        if (isActive) gaugeActiveColor else gaugeInactiveColor
+
+    val gaugeLabelColor =
+        if (isSelected) CherrishTheme.colors.gray900 else CherrishTheme.colors.gray600
+
+    return CherrishGaugeStyle(
+        gaugeLabel = "Lv.$step",
+        gaugeLabelColor = gaugeLabelColor,
+        gaugeLevelColor = gaugeLevelColor,
+        gaugeLevelBorderColor = gaugeLevelBorderColor
+    )
+}

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeStyle.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/gaugebar/CherrishGaugeStyle.kt
@@ -1,9 +1,8 @@
 package com.cherrish.android.core.designsystem.component.gaugebar
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.cherrish.android.core.designsystem.component.type.CherrishGaugeType
-import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.core.designsystem.theme.CherrishColors
 
 data class CherrishGaugeStyle(
     val gaugeLabel: String,
@@ -12,40 +11,25 @@ data class CherrishGaugeStyle(
     val gaugeLevelBorderColor: Color
 )
 
-@Composable
-fun CherrishGaugeType.style(isActive: Boolean, isSelected: Boolean): CherrishGaugeStyle {
-    val gaugeActiveColor = when (this) {
-        CherrishGaugeType.LEVEL1 -> Pair(
-            CherrishTheme.colors.red300,
-            CherrishTheme.colors.red500
-        )
+fun CherrishGaugeType.style(
+    colors: CherrishColors,
+    isActive: Boolean,
+    isSelected: Boolean
+): CherrishGaugeStyle {
+    val gaugeActiveColor = cherrishGaugeActiveColors(
+        gaugeType = this,
+        colors = colors
+    )
 
-        CherrishGaugeType.LEVEL2 -> Pair(
-            CherrishTheme.colors.red400,
-            CherrishTheme.colors.red600
-        )
-
-        CherrishGaugeType.LEVEL3 -> Pair(
-            CherrishTheme.colors.red500,
-            CherrishTheme.colors.red700
-        )
-
-        CherrishGaugeType.LEVEL4 -> Pair(
-            CherrishTheme.colors.red600,
-            CherrishTheme.colors.red800
-        )
-    }
-
-    val gaugeInactiveColor = Pair(
-        CherrishTheme.colors.gray300,
-        CherrishTheme.colors.gray500
+    val gaugeInactiveColor = cherrishGaugeInactiveColors(
+        colors = colors
     )
 
     val (gaugeLevelColor, gaugeLevelBorderColor) =
         if (isActive) gaugeActiveColor else gaugeInactiveColor
 
     val gaugeLabelColor =
-        if (isSelected) CherrishTheme.colors.gray900 else CherrishTheme.colors.gray600
+        if (isSelected) colors.gray900 else colors.gray600
 
     return CherrishGaugeStyle(
         gaugeLabel = "Lv.$step",

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/type/CherrishGaugeType.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/type/CherrishGaugeType.kt
@@ -1,0 +1,10 @@
+package com.cherrish.android.core.designsystem.component.type
+
+enum class CherrishGaugeType(
+    val step: Int
+) {
+    LEVEL1(1),
+    LEVEL2(2),
+    LEVEL3(3),
+    LEVEL4(4)
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #9

## Work Description ✏️
 - 게이지바 공통 컴포넌트 구현



## Screenshot 📸
<img src="" width="360"/><img width="430" height="143" alt="스크린샷 2026-01-09 오후 11 43 53" src="https://github.com/user-attachments/assets/807ef265-064c-4991-88d3-31acee7e42cf" />

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
일단 변수명 다른거 제안해주시는거 적극 환영합니다..!ㅎㅎ
몇몇 변수 이름이 좀 애매할수도 있는거 같은데 마땅한게 떠오르지 않아서 코드 보시다가 제안해주실 부분 있음 맘껏 제안해주세요!!

CherrishGaugeStyle가 GaugeBar의 레벨 단계, 활성/선택 상태에 따른 표현으로 gaugebar와 강하게 결합되어 있어 이걸 공통 스타일로 분리하기 보다는 gaugebar 패키지 내부에 함께 위치시키는 것이 적절하다고 판단하여 gaugebar 내부에 위치시켜놨는데 이것 관련해서 다른 분들의 의견이 궁금합니다아~~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게이지 바 UI 컴포넌트 추가 — 최대 4단계 게이지를 가로로 표시하고 현재 단계에 따라 활성/선택 상태를 반영합니다.
  * 레벨별 색상 및 테두리 구성 제공 — 활성/비활성 상태에 따라 자동으로 색상이 결정됩니다.
  * 라벨 생성 규칙 포함 — 각 레벨에 "Lv.x" 형식 라벨과 선택 상태에 따른 라벨 색상이 적용됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->