### PR TITLE
[FEAT/#28] 공통 텍스트 필드 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -31,6 +31,7 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 fun CherrishTextField(
     value: String,
     onValueChanged: (String) -> Unit,
+    roundedCornerShape: RoundedCornerShape,
     placeholder: String,
     placeholderTextStyle: TextStyle,
     inputTextStyle: TextStyle,
@@ -46,12 +47,12 @@ fun CherrishTextField(
         value = value,
         onValueChange = onValueChanged,
         modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
+            .clip(roundedCornerShape)
             .background(color = CherrishTheme.colors.gray0)
             .border(
                 width = 1.dp,
                 color = CherrishTheme.colors.gray500,
-                shape = RoundedCornerShape(10.dp)
+                shape = roundedCornerShape
             ),
         singleLine = true,
         keyboardOptions = KeyboardOptions(
@@ -93,6 +94,7 @@ private fun CherrishTextFieldPreview() {
         CherrishTextField(
             value = text,
             onValueChanged = { text = it },
+            roundedCornerShape = RoundedCornerShape(10.dp),
             placeholder = "김체리",
             placeholderTextStyle = CherrishTheme.typography.body1R14,
             placeholderTextColor = CherrishTheme.colors.gray500,

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -87,7 +87,7 @@ fun CherrishTextField(
 
 @Preview(showBackground = true, backgroundColor = 0xFF212121)
 @Composable
-private fun CherrishBasicTextFieldPadding16Preview() {
+private fun CherrishTextFieldPreview() {
     var text by remember { mutableStateOf("") }
     CherrishTheme {
         CherrishTextField(

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -29,7 +29,7 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 @Composable
 fun CherrishTextField(
     value: String,
-    onValueChanged: (String) -> Unit,
+    onValueChange: (String) -> Unit,
     roundedCornerShape: RoundedCornerShape,
     placeholder: String,
     placeholderTextStyle: TextStyle,
@@ -49,7 +49,7 @@ fun CherrishTextField(
 
     BasicTextField(
         value = value,
-        onValueChange = onValueChanged,
+        onValueChange = onValueChange,
         modifier = modifier
             .clip(roundedCornerShape)
             .background(color = CherrishTheme.colors.gray0)
@@ -93,7 +93,7 @@ private fun CherrishTextFieldPreview() {
     CherrishTheme {
         CherrishTextField(
             value = text,
-            onValueChanged = { text = it },
+            onValueChange = { text = it },
             roundedCornerShape = RoundedCornerShape(10.dp),
             placeholder = "김체리",
             placeholderTextStyle = CherrishTheme.typography.body1R14,

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -1,0 +1,106 @@
+package com.cherrish.android.core.designsystem.component.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun CherrishTextField(
+    value: String,
+    onValueChanged: (String) -> Unit,
+    placeholder: String,
+    placeholderTextStyle: TextStyle,
+    inputTextStyle: TextStyle,
+    inputTextColor: Color,
+    onDoneAction: () -> Unit = {},
+    paddingValues: PaddingValues,
+    keyboardImeAction: ImeAction = ImeAction.Done,
+    keyboardType: KeyboardType = KeyboardType.Unspecified,
+    placeholderTextColor: Color = CherrishTheme.colors.gray500,
+    modifier: Modifier = Modifier
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = {
+            onValueChanged(it)
+        },
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(color = CherrishTheme.colors.gray0)
+            .border(
+                width = 1.dp,
+                color = CherrishTheme.colors.gray500,
+                shape = RoundedCornerShape(10.dp)
+            ),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = keyboardType,
+            imeAction = keyboardImeAction,
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = { onDoneAction() }
+        ),
+        textStyle = inputTextStyle.copy(
+            color = inputTextColor
+        ),
+        decorationBox = { innerTextField ->
+            Column(
+                modifier = Modifier.padding(paddingValues)
+            ) {
+                Box(
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            color = placeholderTextColor,
+                            style = placeholderTextStyle
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        }
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF212121)
+@Composable
+private fun CherrishBasicTextFieldPadding16Preview() {
+    var text by remember { mutableStateOf("") }
+    CherrishTheme {
+        CherrishTextField(
+            value = text,
+            onValueChanged = { text = it },
+            placeholder = "김체리",
+            placeholderTextStyle = CherrishTheme.typography.body1R14,
+            placeholderTextColor = CherrishTheme.colors.gray500,
+            inputTextStyle = CherrishTheme.typography.body1R14,
+            inputTextColor = CherrishTheme.colors.gray1000,
+            paddingValues = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -58,7 +58,7 @@ fun CherrishTextField(
         singleLine = true,
         keyboardOptions = KeyboardOptions(
             keyboardType = keyboardType,
-            imeAction = keyboardImeAction,
+            imeAction = keyboardImeAction
         ),
         keyboardActions = KeyboardActions(
             onDone = { onDoneAction() }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -37,8 +37,9 @@ fun CherrishTextField(
     inputTextColor: Color,
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
-    onDoneAction: () -> Unit = {},
     keyboardImeAction: ImeAction = ImeAction.Done,
+    onNextAction: () -> Unit = {},
+    onDoneAction: () -> Unit = {},
     keyboardType: KeyboardType = KeyboardType.Unspecified,
     placeholderTextColor: Color = CherrishTheme.colors.gray500
 ) {
@@ -63,6 +64,7 @@ fun CherrishTextField(
             imeAction = keyboardImeAction
         ),
         keyboardActions = KeyboardActions(
+            onNext = { onNextAction() },
             onDone = { onDoneAction() }
         ),
         textStyle = textStyle,

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -44,9 +44,7 @@ fun CherrishTextField(
 ) {
     BasicTextField(
         value = value,
-        onValueChange = {
-            onValueChanged(it)
-        },
+        onValueChange = onValueChanged,
         modifier = modifier
             .clip(RoundedCornerShape(10.dp))
             .background(color = CherrishTheme.colors.gray0)

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -42,6 +42,10 @@ fun CherrishTextField(
     keyboardType: KeyboardType = KeyboardType.Unspecified,
     placeholderTextColor: Color = CherrishTheme.colors.gray500
 ) {
+    val textStyle = remember(inputTextStyle, inputTextColor) {
+        inputTextStyle.copy(color = inputTextColor)
+    }
+
     BasicTextField(
         value = value,
         onValueChange = onValueChanged,
@@ -61,9 +65,7 @@ fun CherrishTextField(
         keyboardActions = KeyboardActions(
             onDone = { onDoneAction() }
         ),
-        textStyle = inputTextStyle.copy(
-            color = inputTextColor
-        ),
+        textStyle = textStyle,
         decorationBox = { innerTextField ->
             Box(
                 modifier = Modifier.padding(paddingValues),

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -35,12 +35,12 @@ fun CherrishTextField(
     placeholderTextStyle: TextStyle,
     inputTextStyle: TextStyle,
     inputTextColor: Color,
-    onDoneAction: () -> Unit = {},
     paddingValues: PaddingValues,
+    modifier: Modifier = Modifier,
+    onDoneAction: () -> Unit = {},
     keyboardImeAction: ImeAction = ImeAction.Done,
     keyboardType: KeyboardType = KeyboardType.Unspecified,
-    placeholderTextColor: Color = CherrishTheme.colors.gray500,
-    modifier: Modifier = Modifier
+    placeholderTextColor: Color = CherrishTheme.colors.gray500
 ) {
     BasicTextField(
         value = value,

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/textfield/CherrishTextField.kt
@@ -3,7 +3,6 @@ package com.cherrish.android.core.designsystem.component.textfield
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -66,21 +65,18 @@ fun CherrishTextField(
             color = inputTextColor
         ),
         decorationBox = { innerTextField ->
-            Column(
-                modifier = Modifier.padding(paddingValues)
+            Box(
+                modifier = Modifier.padding(paddingValues),
+                contentAlignment = Alignment.CenterStart
             ) {
-                Box(
-                    contentAlignment = Alignment.CenterStart
-                ) {
-                    if (value.isEmpty()) {
-                        Text(
-                            text = placeholder,
-                            color = placeholderTextColor,
-                            style = placeholderTextStyle
-                        )
-                    }
-                    innerTextField()
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        color = placeholderTextColor,
+                        style = placeholderTextStyle
+                    )
                 }
+                innerTextField()
             }
         }
     )


### PR DESCRIPTION
## Related issue 🛠
- closed #28 

## Work Description ✏️
 - 공통으로 필요한 텍스트 필드 컴포넌트를 구현했습니다.

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/59bce436-a49c-42c5-972f-1ccc02b2b318" width="360"/>

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
배경색과 보더를 제외한 대부분의 속성은 파라미터로 분리해두었습니다.
사용 시 해당 부분 참고해서 활용해주세용 !!
프리뷰 코드도 함께 작성해두었으니 같이 확인 부탁드립니다잉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 완전히 커스터마이징 가능한 텍스트 입력 컴포넌트가 추가되었습니다. 플레이스홀더 표시, 입력 텍스트 스타일/색상, 둥근 모서리, 내부 패딩, 키보드 유형 및 완료/다음 액션 콜백 등을 구성할 수 있으며, 빈 입력 시 자동으로 플레이스홀더가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->