### PR TITLE
[MOD/#29] 공통선택칩 컴포넌트 코드리뷰 반영 

### DIFF
--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionBaseChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionBaseChip.kt
@@ -1,0 +1,55 @@
+package com.cherrish.android.core.designsystem.component.chip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.common.extension.noRippleClickable
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
+
+@Composable
+fun CherrishSelectionBaseChip(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    style: CherrishSelectionChipStyle = CherrishSelectionChipStyle.SELECTIONCHIP,
+    content: @Composable () -> Unit
+) {
+    val backgroundColor = when (style) {
+        CherrishSelectionChipStyle.SELECTIONCHIP -> {
+            if (isSelected) CherrishTheme.colors.red200 else CherrishTheme.colors.gray0
+        }
+
+        CherrishSelectionChipStyle.MISSIONCARD -> {
+            if (isSelected) CherrishTheme.colors.red100 else CherrishTheme.colors.gray0
+        }
+    }
+
+    val lineColor = if (isSelected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
+
+    val cornerRadius = when (style) {
+        CherrishSelectionChipStyle.SELECTIONCHIP -> 10.dp
+        CherrishSelectionChipStyle.MISSIONCARD -> 9.dp
+    }
+
+    Column(
+        modifier = Modifier
+            .clip(shape = RoundedCornerShape(size = cornerRadius))
+            .background(backgroundColor)
+            .border(
+                width = 1.dp,
+                color = lineColor,
+                shape = RoundedCornerShape(size = cornerRadius)
+            )
+            .noRippleClickable(onClick = onClick)
+            .then(other = modifier)
+
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -1,17 +1,7 @@
 package com.cherrish.android.core.designsystem.component.chip
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -19,69 +9,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.cherrish.android.R
-import com.cherrish.android.core.common.extension.noRippleClickable
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
-import com.cherrish.android.core.designsystem.theme.gray500
-import com.cherrish.android.core.designsystem.theme.red700
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
-
-@Composable
-fun CherrishSelectionBaseChip(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    style: CherrishSelectionChipStyle = CherrishSelectionChipStyle.SELECTIONCHIP,
-    content: @Composable () -> Unit
-) {
-    val backgroundColor = when (style) {
-        CherrishSelectionChipStyle.SELECTIONCHIP -> {
-            if (isSelected) CherrishTheme.colors.red200 else CherrishTheme.colors.gray0
-        }
-
-        CherrishSelectionChipStyle.MISSIONCARD -> {
-            if (isSelected) CherrishTheme.colors.red100 else CherrishTheme.colors.gray0
-        }
-    }
-
-    val lineColor = if (isSelected) CherrishTheme.colors.red500 else CherrishTheme.colors.gray500
-
-    val cornerRadius = when (style) {
-        CherrishSelectionChipStyle.SELECTIONCHIP -> 10.dp
-        CherrishSelectionChipStyle.MISSIONCARD -> 9.dp
-    }
-
-    val paddingValues = when (style) {
-        CherrishSelectionChipStyle.SELECTIONCHIP -> PaddingValues(
-            horizontal = 10.dp,
-            vertical = 30.dp
-        )
-
-        CherrishSelectionChipStyle.MISSIONCARD -> PaddingValues(horizontal = 7.dp, vertical = 6.dp)
-    }
-
-    Column(
-        modifier = modifier
-            .clip(shape = RoundedCornerShape(size = cornerRadius))
-            .background(backgroundColor)
-            .border(
-                width = 1.dp,
-                color = lineColor,
-                shape = RoundedCornerShape(size = cornerRadius)
-            )
-            .noRippleClickable(onClick = onClick)
-            .padding(paddingValues)
-
-    ) {
-        content()
-    }
-}
 
 @Composable
 fun CherrishSelectionChip(
@@ -101,52 +33,10 @@ fun CherrishSelectionChip(
         Text(
             text = text,
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 40.dp),
+                .fillMaxWidth().padding(vertical = 30.dp, horizontal = 10.dp),
             color = textColor,
             textAlign = TextAlign.Center
         )
-    }
-}
-
-@Composable
-fun CherrishMissionCardChip(
-    text: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false
-) {
-    val textColor = if (isSelected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
-
-    CherrishSelectionBaseChip(
-        onClick = onClick,
-        modifier = modifier,
-        isSelected = isSelected,
-        style = CherrishSelectionChipStyle.MISSIONCARD
-    ) {
-        Column(
-            modifier = Modifier
-        ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    id = if (isSelected) {
-                        R.drawable.ic_radiobtn_selected
-                    } else {
-                        R.drawable.ic_radiobtn_default
-                    }
-                ),
-                tint = if (isSelected) red700 else gray500,
-                contentDescription = null,
-                modifier = Modifier.weight(1f).padding(start = 110.dp)
-            )
-
-            Text(
-                text = text,
-                color = textColor,
-                modifier = Modifier
-                    .weight(weight = 1f)
-            )
-        }
     }
 }
 
@@ -158,62 +48,10 @@ private fun CherrishSelectionChipPreview() {
 
         CherrishSelectionChip(
             text = "여드름 ∙ 트러블",
-
             onClick = { isSelected = !isSelected },
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(60.dp),
+                .fillMaxWidth(),
             isSelected = isSelected
         )
-    }
-}
-
-@Preview
-@Composable
-private fun CherrishMissionCardPreview() {
-    CherrishTheme {
-        var isSelected by remember { mutableStateOf(value = false) }
-
-        CherrishMissionCardChip(
-            text = "반신욕 20분",
-
-            onClick = { isSelected = !isSelected },
-            modifier = Modifier
-                .width(width = 148.dp)
-                .height(height = 80.dp),
-            isSelected = isSelected
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun CherrishMissionCardRowPreview() {
-    CherrishTheme {
-        var isSelected by remember { mutableStateOf(value = false) }
-
-        Row(
-            modifier = Modifier,
-            horizontalArrangement = Arrangement.spacedBy(space = 12.dp)
-        ) {
-            CherrishMissionCardChip(
-                text = "반신욕 20분",
-
-                onClick = { isSelected = !isSelected },
-                modifier = Modifier
-                    .width(width = 148.dp)
-                    .height(height = 80.dp),
-                isSelected = isSelected
-            )
-            CherrishMissionCardChip(
-                text = "반신욕 30분",
-                onClick = { isSelected = !isSelected },
-                modifier = Modifier
-                    .width(width = 148.dp)
-                    .height(height = 80.dp),
-                isSelected = isSelected
-
-            )
-        }
     }
 }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -33,7 +33,8 @@ fun CherrishSelectionChip(
         Text(
             text = text,
             modifier = Modifier
-                .fillMaxWidth().padding(vertical = 30.dp, horizontal = 10.dp),
+                .fillMaxWidth()
+                .padding(vertical = 30.dp, horizontal = 10.dp),
             color = textColor,
             textAlign = TextAlign.Center
         )

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionChip.kt
@@ -2,11 +2,14 @@ package com.cherrish.android.core.designsystem.component.chip
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -15,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -66,7 +68,6 @@ fun CherrishSelectionBaseChip(
 
     Column(
         modifier = modifier
-            .fillMaxWidth()
             .clip(shape = RoundedCornerShape(size = cornerRadius))
             .background(backgroundColor)
             .border(
@@ -85,16 +86,16 @@ fun CherrishSelectionBaseChip(
 @Composable
 fun CherrishSelectionChip(
     text: String,
-    selected: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false
 ) {
-    val textColor = if (selected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
+    val textColor = if (isSelected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
     CherrishSelectionBaseChip(
         onClick = onClick,
         modifier = modifier,
-        isSelected = selected,
+        isSelected = isSelected,
         style = CherrishSelectionChipStyle.SELECTIONCHIP
     ) {
         Text(
@@ -111,49 +112,39 @@ fun CherrishSelectionChip(
 @Composable
 fun CherrishMissionCardChip(
     text: String,
-    selected: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false
 ) {
-    val textColor =
-        if (selected) {
-            CherrishTheme.colors.gray800
-        } else {
-            CherrishTheme.colors.gray700
-        }
+    val textColor = if (isSelected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
 
     CherrishSelectionBaseChip(
         onClick = onClick,
         modifier = modifier,
-        isSelected = selected,
+        isSelected = isSelected,
         style = CherrishSelectionChipStyle.MISSIONCARD
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth()
+        Column(
+            modifier = Modifier
         ) {
-            Text(
-                text = text,
-                color = textColor,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(
-                        start = 7.dp,
-                        top = 38.dp,
-                        bottom = 6.dp
-                    )
-            )
-
             Icon(
                 imageVector = ImageVector.vectorResource(
-                    id = if (selected) {
+                    id = if (isSelected) {
                         R.drawable.ic_radiobtn_selected
                     } else {
                         R.drawable.ic_radiobtn_default
                     }
                 ),
-                tint = if (selected) red700 else gray500,
+                tint = if (isSelected) red700 else gray500,
                 contentDescription = null,
-                modifier = Modifier.align(Alignment.TopEnd)
+                modifier = Modifier.weight(1f).padding(start = 110.dp)
+            )
+
+            Text(
+                text = text,
+                color = textColor,
+                modifier = Modifier
+                    .weight(weight = 1f)
             )
         }
     }
@@ -163,15 +154,16 @@ fun CherrishMissionCardChip(
 @Composable
 private fun CherrishSelectionChipPreview() {
     CherrishTheme {
-        var selected by remember { mutableStateOf(value = false) }
+        var isSelected by remember { mutableStateOf(value = false) }
 
         CherrishSelectionChip(
             text = "여드름 ∙ 트러블",
-            selected = selected,
-            onClick = { selected = !selected },
+
+            onClick = { isSelected = !isSelected },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(60.dp)
+                .padding(60.dp),
+            isSelected = isSelected
         )
     }
 }
@@ -180,15 +172,48 @@ private fun CherrishSelectionChipPreview() {
 @Composable
 private fun CherrishMissionCardPreview() {
     CherrishTheme {
-        var selected by remember { mutableStateOf(value = false) }
+        var isSelected by remember { mutableStateOf(value = false) }
 
         CherrishMissionCardChip(
             text = "반신욕 20분",
-            selected = selected,
-            onClick = { selected = !selected },
+
+            onClick = { isSelected = !isSelected },
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(30.dp)
+                .width(width = 148.dp)
+                .height(height = 80.dp),
+            isSelected = isSelected
         )
+    }
+}
+
+@Preview
+@Composable
+private fun CherrishMissionCardRowPreview() {
+    CherrishTheme {
+        var isSelected by remember { mutableStateOf(value = false) }
+
+        Row(
+            modifier = Modifier,
+            horizontalArrangement = Arrangement.spacedBy(space = 12.dp)
+        ) {
+            CherrishMissionCardChip(
+                text = "반신욕 20분",
+
+                onClick = { isSelected = !isSelected },
+                modifier = Modifier
+                    .width(width = 148.dp)
+                    .height(height = 80.dp),
+                isSelected = isSelected
+            )
+            CherrishMissionCardChip(
+                text = "반신욕 30분",
+                onClick = { isSelected = !isSelected },
+                modifier = Modifier
+                    .width(width = 148.dp)
+                    .height(height = 80.dp),
+                isSelected = isSelected
+
+            )
+        }
     }
 }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
@@ -40,7 +40,9 @@ fun CherrishMissionCardChip(
         style = CherrishSelectionChipStyle.MISSIONCARD
     ) {
         Box(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp, horizontal = 7.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 6.dp, horizontal = 8.dp)
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(
@@ -52,18 +54,16 @@ fun CherrishMissionCardChip(
                 ),
                 tint = if (isSelected) red700 else gray500,
                 contentDescription = null,
-                modifier = modifier.align(Alignment.TopEnd)
+                modifier = Modifier.align(Alignment.TopEnd)
 
             )
 
             Text(
                 text = text,
                 color = textColor,
-                modifier = modifier.align(Alignment.BottomStart).padding(
-                    top = 44.dp,
-                    start = 8.dp,
-                    bottom = 6.dp
-                )
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(top = 44.dp, start = 8.dp, bottom = 6.dp)
             )
         }
     }
@@ -78,7 +78,6 @@ private fun CherrishMissionCardPreview() {
         CherrishMissionCardChip(
             text = "반신욕 20분",
             onClick = { isSelected = !isSelected },
-            modifier = Modifier,
             isSelected = isSelected
         )
     }
@@ -91,20 +90,20 @@ private fun CherrishMissionCardRowPreview() {
         var isSelected by remember { mutableStateOf(value = false) }
 
         Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp, horizontal = 7.dp),
-
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 6.dp, horizontal = 7.dp),
             horizontalArrangement = Arrangement.spacedBy(space = 12.dp)
         ) {
             CherrishMissionCardChip(
                 text = "반신욕 20분",
                 onClick = { isSelected = !isSelected },
-                modifier = Modifier,
                 isSelected = isSelected
             )
+
             CherrishMissionCardChip(
                 text = "반신욕 30분",
                 onClick = { isSelected = !isSelected },
-                modifier = Modifier,
                 isSelected = isSelected
 
             )

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
@@ -24,7 +24,6 @@ import com.cherrish.android.core.designsystem.theme.gray500
 import com.cherrish.android.core.designsystem.theme.red700
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 
-
 @Composable
 fun CherrishMissionCardChip(
     text: String,
@@ -41,7 +40,7 @@ fun CherrishMissionCardChip(
         style = CherrishSelectionChipStyle.MISSIONCARD
     ) {
         Box(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp, horizontal = 7.dp),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp, horizontal = 7.dp)
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(
@@ -55,13 +54,16 @@ fun CherrishMissionCardChip(
                 contentDescription = null,
                 modifier = modifier.align(Alignment.TopEnd)
 
-
             )
 
             Text(
                 text = text,
                 color = textColor,
-                modifier = modifier.align(Alignment.BottomStart).padding(top = 44.dp, start = 8.dp, bottom = 6.dp)
+                modifier = modifier.align(Alignment.BottomStart).padding(
+                    top = 44.dp,
+                    start = 8.dp,
+                    bottom = 6.dp
+                )
             )
         }
     }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
@@ -1,0 +1,111 @@
+package com.cherrish.android.core.designsystem.component.chip
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.R
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.core.designsystem.theme.gray500
+import com.cherrish.android.core.designsystem.theme.red700
+import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
+
+
+@Composable
+fun CherrishMissionCardChip(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false
+) {
+    val textColor = if (isSelected) CherrishTheme.colors.gray800 else CherrishTheme.colors.gray700
+
+    CherrishSelectionBaseChip(
+        onClick = onClick,
+        modifier = modifier,
+        isSelected = isSelected,
+        style = CherrishSelectionChipStyle.MISSIONCARD
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp, horizontal = 7.dp),
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(
+                    id = if (isSelected) {
+                        R.drawable.ic_radiobtn_selected
+                    } else {
+                        R.drawable.ic_radiobtn_default
+                    }
+                ),
+                tint = if (isSelected) red700 else gray500,
+                contentDescription = null,
+                modifier = modifier.align(Alignment.TopEnd)
+
+
+            )
+
+            Text(
+                text = text,
+                color = textColor,
+                modifier = modifier.align(Alignment.BottomStart).padding(top = 44.dp, start = 8.dp, bottom = 6.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CherrishMissionCardPreview() {
+    CherrishTheme {
+        var isSelected by remember { mutableStateOf(value = false) }
+
+        CherrishMissionCardChip(
+            text = "반신욕 20분",
+            onClick = { isSelected = !isSelected },
+            modifier = Modifier,
+            isSelected = isSelected
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CherrishMissionCardRowPreview() {
+    CherrishTheme {
+        var isSelected by remember { mutableStateOf(value = false) }
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp, horizontal = 7.dp),
+
+            horizontalArrangement = Arrangement.spacedBy(space = 12.dp)
+        ) {
+            CherrishMissionCardChip(
+                text = "반신욕 20분",
+                onClick = { isSelected = !isSelected },
+                modifier = Modifier,
+                isSelected = isSelected
+            )
+            CherrishMissionCardChip(
+                text = "반신욕 30분",
+                onClick = { isSelected = !isSelected },
+                modifier = Modifier,
+                isSelected = isSelected
+
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/chip/CherrishSelectionMissionChip.kt
@@ -25,7 +25,7 @@ import com.cherrish.android.core.designsystem.theme.red700
 import com.cherrish.android.core.designsystem.type.CherrishSelectionChipStyle
 
 @Composable
-fun CherrishMissionCardChip(
+fun CherrishMissionCard(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -75,7 +75,7 @@ private fun CherrishMissionCardPreview() {
     CherrishTheme {
         var isSelected by remember { mutableStateOf(value = false) }
 
-        CherrishMissionCardChip(
+        CherrishMissionCard(
             text = "반신욕 20분",
             onClick = { isSelected = !isSelected },
             isSelected = isSelected
@@ -95,13 +95,13 @@ private fun CherrishMissionCardRowPreview() {
                 .padding(vertical = 6.dp, horizontal = 7.dp),
             horizontalArrangement = Arrangement.spacedBy(space = 12.dp)
         ) {
-            CherrishMissionCardChip(
+            CherrishMissionCard(
                 text = "반신욕 20분",
                 onClick = { isSelected = !isSelected },
                 isSelected = isSelected
             )
 
-            CherrishMissionCardChip(
+            CherrishMissionCard(
                 text = "반신욕 30분",
                 onClick = { isSelected = !isSelected },
                 isSelected = isSelected


### PR DESCRIPTION
공통 선택칩 컴포넌트 구현
- 기존에 padding 강제지정 -> fillMaxWidth()와 weight로 구현 -CherrishSelectionChipRow 구현

## Related issue 🛠
- closed #29 

## Work Description ✏️

- 기존 코드리뷰 반영 
- 기존 padding 값으로 강제 레이아웃하던 구조 제거
- fillMaxWidth() + weight 기반 레이아웃으로 개선
- Selection / MissionCard 스타일별 전용 컴포넌트 분리
- 여러 선택칩을 가로로 배치할 수 있는 CherrishSelectionChipRow 구현


## Screenshot 📸
<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/d0f1ed88-47c3-4286-b44a-09a5155dd24a" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
코드리뷰 부탁드립니당 :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 미션 카드 형태의 선택 칩 추가 — 선택에 따라 아이콘·색상·레이아웃이 변경되며 프리뷰 포함

* **Refactor**
  * 공개 API 파라미터명을 selected → isSelected로 통일하고 기본값 추가
  * 칩 내부 레이아웃과 텍스트 패딩 조정으로 기본 간격 및 시각적 형태 변경
  * 스타일 책임 분리용 기본 칩 컴포넌트 도입 및 기존 구현 정리/간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->