### PR TITLE
[FEAT/#38] 시술/챌린지 공통 섹션 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -17,17 +17,24 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.component.chip.CherrishMissionCard
 import com.cherrish.android.core.designsystem.component.chip.CherrishSelectionChip
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+enum class CherrishSectionChipType {
+    SELECTION_CHIP,
+    MISSION_CARD
+}
 
 @Composable
 fun CherrishSelectionSection(
     title: String,
     items: List<String>,
+    chipType: CherrishSectionChipType,
+    onItemClick: (index: Int) -> Unit,
     modifier: Modifier = Modifier,
     description: String? = null,
-    selectedIndex: Int? = null,
-    onItemClick: (index: Int) -> Unit
+    selectedIndex: Int? = null
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
@@ -42,7 +49,8 @@ fun CherrishSelectionSection(
         SelectionChipGrid(
             items = items,
             selectedIndex = selectedIndex,
-            onItemClick = onItemClick
+            onItemClick = onItemClick,
+            chipType = chipType
         )
     }
 }
@@ -50,9 +58,10 @@ fun CherrishSelectionSection(
 @Composable
 private fun SelectionChipGrid(
     items: List<String>,
+    chipType: CherrishSectionChipType,
+    onItemClick: (index: Int) -> Unit,
     modifier: Modifier = Modifier,
-    selectedIndex: Int? = null,
-    onItemClick: (index: Int) -> Unit
+    selectedIndex: Int? = null
 ) {
     LazyVerticalGrid(
         modifier = modifier.fillMaxWidth(),
@@ -62,12 +71,25 @@ private fun SelectionChipGrid(
         userScrollEnabled = false
     ) {
         itemsIndexed(items) { index, text ->
-            CherrishSelectionChip(
-                text = text,
-                onClick = { onItemClick(index) },
-                modifier = Modifier.fillMaxWidth(),
-                isSelected = selectedIndex == index
-            )
+            when (chipType) {
+                CherrishSectionChipType.SELECTION_CHIP -> {
+                    CherrishSelectionChip(
+                        text = text,
+                        onClick = { onItemClick(index) },
+                        modifier = Modifier.fillMaxWidth(),
+                        isSelected = selectedIndex == index
+                    )
+                }
+
+                CherrishSectionChipType.MISSION_CARD -> {
+                    CherrishMissionCard(
+                        text = text,
+                        onClick = { onItemClick(index) },
+                        modifier = Modifier.fillMaxWidth(),
+                        isSelected = selectedIndex == index
+                    )
+                }
+            }
         }
     }
 }
@@ -100,32 +122,34 @@ private fun TitleDescriptionSection(
 
 @Preview(showBackground = true)
 @Composable
-private fun CherrishSelectionSectionPreview_TwoOptions() {
+private fun CherrishSelectionSectionPreview_SelectionChip() {
     CherrishTheme {
         var isSelected by remember { mutableIntStateOf(-1) }
 
         CherrishSelectionSection(
-            title = "시술 일정을 추가해볼게요.\n이미 생각해둔 시술이 있나요?",
-            description = "시술을 선택하셨는지 확인할게요.",
-            items = listOf("선택한 시술이 있어요", "아직 선택 전이에요"),
+            title = "요즘 가장 신경 쓰이는\n피부 고민은 무엇인가요?",
+            description = "선택한 고민을 기준으로 시술 정보를 정리해줘요.",
+            items = listOf("피부결·각질", "색소·잡티", "홍조", "탄력·주름", "모공", "트러블"),
             selectedIndex = isSelected,
-            onItemClick = { isSelected = it }
+            onItemClick = { isSelected = it },
+            chipType = CherrishSectionChipType.SELECTION_CHIP
         )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun CherrishSelectionSectionPreview_SixOptions() {
+private fun CherrishSelectionSectionPreview_MissionCard() {
     CherrishTheme {
         var isSelected by remember { mutableIntStateOf(-1) }
 
         CherrishSelectionSection(
-            title = "요즘 가장 신경 쓰이는\n피부 고민은 무엇인가요?",
-            description = "선택한 고민 기준으로 시술 정보를 정리해드려요.",
-            items = listOf("피부결·각질", "색소·잡티", "홍조", "탄력·주름", "모공", "트러블"),
+            title = "챌린지 기간 동안\n진행할 미션을 선택해주세요.",
+            description = "복수 선택이 가능해요.",
+            items = listOf("반신욕 20분", "진정 토너+세럼", "피부결 정돈", "괄사", "톤 개선", "선크림 바르기"),
             selectedIndex = isSelected,
-            onItemClick = { isSelected = it }
+            onItemClick = { isSelected = it },
+            chipType = CherrishSectionChipType.MISSION_CARD
         )
     }
 }

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -67,7 +67,10 @@ private fun SelectionChipGrid(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        itemsIndexed(items) { index, text ->
+        itemsIndexed(
+            items = items,
+            key = { index, item -> "$item-$index" }
+        ) { index, text ->
             when (chipType) {
                 CherrishSectionChipType.SELECTION_CHIP -> {
                     CherrishSelectionChip(

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -19,12 +19,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cherrish.android.core.designsystem.component.chip.CherrishMissionCard
 import com.cherrish.android.core.designsystem.component.chip.CherrishSelectionChip
+import com.cherrish.android.core.designsystem.component.type.CherrishSectionChipType
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
-
-enum class CherrishSectionChipType {
-    SELECTION_CHIP,
-    MISSION_CARD
-}
 
 @Composable
 fun CherrishSelectionSection(

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -107,6 +107,7 @@ private fun TitleDescriptionSection(
 
         if (!description.isNullOrBlank()) {
             Spacer(modifier = Modifier.height(4.dp))
+
             Text(
                 text = description,
                 style = CherrishTheme.typography.body1R14,
@@ -118,7 +119,7 @@ private fun TitleDescriptionSection(
 
 @Preview(showBackground = true)
 @Composable
-private fun CherrishSelectionSectionPreview_SelectionChip() {
+private fun SelectionSectionSelectionChipPreview() {
     CherrishTheme {
         var isSelected by remember { mutableIntStateOf(-1) }
 
@@ -135,7 +136,7 @@ private fun CherrishSelectionSectionPreview_SelectionChip() {
 
 @Preview(showBackground = true)
 @Composable
-private fun CherrishSelectionSectionPreview_MissionCard() {
+private fun SelectionSectionMissionCardPreview() {
     CherrishTheme {
         var isSelected by remember { mutableIntStateOf(-1) }
 

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cherrish.android.core.designsystem.component.chip.CherrishMissionCard
@@ -27,6 +28,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 fun CherrishSelectionSection(
     title: String,
+    descriptionTextStyle: TextStyle,
     items: ImmutableList<String>,
     chipType: CherrishSectionChipType,
     onItemClick: (index: Int) -> Unit,
@@ -39,6 +41,7 @@ fun CherrishSelectionSection(
     ) {
         TitleDescriptionSection(
             title = title,
+            descriptionTextStyle = descriptionTextStyle,
             description = description
         )
 
@@ -97,6 +100,7 @@ private fun SelectionChipGrid(
 @Composable
 private fun TitleDescriptionSection(
     title: String,
+    descriptionTextStyle: TextStyle,
     modifier: Modifier = Modifier,
     description: String? = null
 ) {
@@ -114,7 +118,7 @@ private fun TitleDescriptionSection(
 
             Text(
                 text = description,
-                style = CherrishTheme.typography.body1R14,
+                style = descriptionTextStyle,
                 color = CherrishTheme.colors.gray700
             )
         }
@@ -130,6 +134,7 @@ private fun SelectionSectionSelectionChipPreview() {
         CherrishSelectionSection(
             title = "요즘 가장 신경 쓰이는\n피부 고민은 무엇인가요?",
             description = "선택한 고민을 기준으로 시술 정보를 정리해줘요.",
+            descriptionTextStyle = CherrishTheme.typography.body1R14,
             items = persistentListOf("여드름 ∙ 트러블", "진정 토너+세럼", "피부결 정돈"),
             selectedIndex = isSelected,
             onItemClick = { isSelected = it },
@@ -147,6 +152,7 @@ private fun SelectionSectionMissionCardPreview() {
         CherrishSelectionSection(
             title = "챌린지 기간 동안\n진행할 미션을 선택해주세요.",
             description = "복수 선택이 가능해요.",
+            descriptionTextStyle = CherrishTheme.typography.body1M14,
             items = persistentListOf("반신욕 20분", "진정 토너+세럼", "피부결 정돈", "괄사", "톤 개선", "선크림 바르기"),
             selectedIndex = isSelected,
             onItemClick = { isSelected = it },

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -21,11 +21,13 @@ import com.cherrish.android.core.designsystem.component.chip.CherrishMissionCard
 import com.cherrish.android.core.designsystem.component.chip.CherrishSelectionChip
 import com.cherrish.android.core.designsystem.component.type.CherrishSectionChipType
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun CherrishSelectionSection(
     title: String,
-    items: List<String>,
+    items: ImmutableList<String>,
     chipType: CherrishSectionChipType,
     onItemClick: (index: Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -53,7 +55,7 @@ fun CherrishSelectionSection(
 
 @Composable
 private fun SelectionChipGrid(
-    items: List<String>,
+    items: ImmutableList<String>,
     chipType: CherrishSectionChipType,
     onItemClick: (index: Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -126,7 +128,7 @@ private fun SelectionSectionSelectionChipPreview() {
         CherrishSelectionSection(
             title = "요즘 가장 신경 쓰이는\n피부 고민은 무엇인가요?",
             description = "선택한 고민을 기준으로 시술 정보를 정리해줘요.",
-            items = listOf("피부결·각질", "색소·잡티", "홍조", "탄력·주름", "모공", "트러블"),
+            items = persistentListOf("여드름 ∙ 트러블", "진정 토너+세럼", "피부결 정돈"),
             selectedIndex = isSelected,
             onItemClick = { isSelected = it },
             chipType = CherrishSectionChipType.SELECTION_CHIP
@@ -143,7 +145,7 @@ private fun SelectionSectionMissionCardPreview() {
         CherrishSelectionSection(
             title = "챌린지 기간 동안\n진행할 미션을 선택해주세요.",
             description = "복수 선택이 가능해요.",
-            items = listOf("반신욕 20분", "진정 토너+세럼", "피부결 정돈", "괄사", "톤 개선", "선크림 바르기"),
+            items = persistentListOf("반신욕 20분", "진정 토너+세럼", "피부결 정돈", "괄사", "톤 개선", "선크림 바르기"),
             selectedIndex = isSelected,
             onItemClick = { isSelected = it },
             chipType = CherrishSectionChipType.MISSION_CARD

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -1,4 +1,4 @@
-package com.cherrish.android.presentation.calendar.procedure.component
+package com.cherrish.android.core.designsystem.component.section
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,7 +21,7 @@ import com.cherrish.android.core.designsystem.component.chip.CherrishSelectionCh
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
-fun SelectionSection(
+fun CherrishSelectionSection(
     title: String,
     items: List<String>,
     modifier: Modifier = Modifier,
@@ -48,7 +48,7 @@ fun SelectionSection(
 }
 
 @Composable
-fun SelectionChipGrid(
+private fun SelectionChipGrid(
     items: List<String>,
     modifier: Modifier = Modifier,
     selectedIndex: Int? = null,
@@ -100,11 +100,11 @@ private fun TitleDescriptionSection(
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectionGridSectionPreview_TwoOptions() {
+private fun CherrishSelectionSectionPreview_TwoOptions() {
     CherrishTheme {
         var isSelected by remember { mutableIntStateOf(-1) }
 
-        SelectionSection(
+        CherrishSelectionSection(
             title = "시술 일정을 추가해볼게요.\n이미 생각해둔 시술이 있나요?",
             description = "시술을 선택하셨는지 확인할게요.",
             items = listOf("선택한 시술이 있어요", "아직 선택 전이에요"),
@@ -116,11 +116,11 @@ private fun SelectionGridSectionPreview_TwoOptions() {
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectionGridSectionPreview_SixOptions() {
+private fun CherrishSelectionSectionPreview_SixOptions() {
     CherrishTheme {
         var isSelected by remember { mutableIntStateOf(-1) }
 
-        SelectionSection(
+        CherrishSelectionSection(
             title = "요즘 가장 신경 쓰이는\n피부 고민은 무엇인가요?",
             description = "선택한 고민 기준으로 시술 정보를 정리해드려요.",
             items = listOf("피부결·각질", "색소·잡티", "홍조", "탄력·주름", "모공", "트러블"),

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/section/CherrishSelectionSection.kt
@@ -65,8 +65,7 @@ private fun SelectionChipGrid(
         modifier = modifier.fillMaxWidth(),
         columns = GridCells.Fixed(2),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        userScrollEnabled = false
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         itemsIndexed(items) { index, text ->
             when (chipType) {

--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/type/CherrishSectionChipType.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/type/CherrishSectionChipType.kt
@@ -1,0 +1,6 @@
+package com.cherrish.android.core.designsystem.component.type
+
+enum class CherrishSectionChipType {
+    SELECTION_CHIP,
+    MISSION_CARD
+}

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectionSection.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectionSection.kt
@@ -1,0 +1,131 @@
+package com.cherrish.android.presentation.calendar.procedure.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.component.chip.CherrishSelectionChip
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun SelectionSection(
+    title: String,
+    items: List<String>,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    selectedIndex: Int? = null,
+    onItemClick: (index: Int) -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        TitleDescriptionSection(
+            title = title,
+            description = description
+        )
+
+        Spacer(modifier = Modifier.height(40.dp))
+
+        SelectionChipGrid(
+            items = items,
+            selectedIndex = selectedIndex,
+            onItemClick = onItemClick
+        )
+    }
+}
+
+@Composable
+fun SelectionChipGrid(
+    items: List<String>,
+    modifier: Modifier = Modifier,
+    selectedIndex: Int? = null,
+    onItemClick: (index: Int) -> Unit
+) {
+    LazyVerticalGrid(
+        modifier = modifier.fillMaxWidth(),
+        columns = GridCells.Fixed(2),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        userScrollEnabled = false
+    ) {
+        itemsIndexed(items) { index, text ->
+            CherrishSelectionChip(
+                text = text,
+                onClick = { onItemClick(index) },
+                modifier = Modifier.fillMaxWidth(),
+                isSelected = selectedIndex == index
+            )
+        }
+    }
+}
+
+@Composable
+private fun TitleDescriptionSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    description: String? = null
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = title,
+            style = CherrishTheme.typography.title1SB18,
+            color = CherrishTheme.colors.gray1000
+        )
+
+        if (!description.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = description,
+                style = CherrishTheme.typography.body1R14,
+                color = CherrishTheme.colors.gray700
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SelectionGridSectionPreview_TwoOptions() {
+    CherrishTheme {
+        var isSelected by remember { mutableIntStateOf(-1) }
+
+        SelectionSection(
+            title = "시술 일정을 추가해볼게요.\n이미 생각해둔 시술이 있나요?",
+            description = "시술을 선택하셨는지 확인할게요.",
+            items = listOf("선택한 시술이 있어요", "아직 선택 전이에요"),
+            selectedIndex = isSelected,
+            onItemClick = { isSelected = it }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SelectionGridSectionPreview_SixOptions() {
+    CherrishTheme {
+        var isSelected by remember { mutableIntStateOf(-1) }
+
+        SelectionSection(
+            title = "요즘 가장 신경 쓰이는\n피부 고민은 무엇인가요?",
+            description = "선택한 고민 기준으로 시술 정보를 정리해드려요.",
+            items = listOf("피부결·각질", "색소·잡티", "홍조", "탄력·주름", "모공", "트러블"),
+            selectedIndex = isSelected,
+            onItemClick = { isSelected = it }
+        )
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #38 

## Work Description ✏️
 - 시술/챌린지 뷰 공통 섹션 컴포넌트를 구현했습니다.

## Screenshot 📸
| SelectionSection_SeclectionChip | SelectionSection_MissionChip |
|:--:|:--:|
| <img width="300" src="https://github.com/user-attachments/assets/8015a3e8-3249-474a-a348-df363d39e946" /> | <img width="300" src="https://github.com/user-attachments/assets/8ae14d80-a7fe-4155-acda-fe801408c34f" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
시술 플로우와 챌린지 플로우에서 사용 가능한 공통 섹션 컴포넌트를 구현했슴!
칩 타입을 선택할 수 있어요.
프리뷰 코드도 넣어놧어요.
혜민띠 챌린지 뷰 구현할 때 사용하시면 됩니다옹 공통 컴포넌트 section 패키지에 넣어놧어요 !!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 제목과 선택적 설명을 표시하는 선택 섹션 컴포넌트 추가: 2열 그리드로 항목을 배치하고 항목 클릭 시 해당 인덱스를 전달하는 콜백을 지원합니다.
  * 표시 방식 확장: 선택형 칩과 미션 카드 두 가지 변형을 지원하여 UI 구성 유연성 향상.
  * 동작·스타일 검증용 프리뷰 추가: 두 변형의 상호작용과 테마 일관성 확인 가능.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->