### PR TITLE
[FEAT/#40] 시술 리스트 타이틀 섹션 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
@@ -1,9 +1,8 @@
 package com.cherrish.android.presentation.calendar.procedure.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,16 +15,14 @@ fun CautionDescription(
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Text(
             text = "◎",
             style = CherrishTheme.typography.body3R12,
             color = CherrishTheme.colors.gray600
         )
-
-        Spacer(modifier = Modifier.size(4.dp))
 
         Text(
             text = "본 정보는 인터넷 빅데이터 검색 및 분석을 통해 " +

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
@@ -1,0 +1,50 @@
+package com.cherrish.android.presentation.calendar.procedure.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun CautionDescription(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = "◎",
+            modifier = modifier,
+            style = CherrishTheme.typography.body3R12,
+            color = CherrishTheme.colors.gray600
+        )
+
+        Spacer(modifier = Modifier.size(4.dp))
+
+        Text(
+            text = text,
+            modifier = modifier,
+            style = CherrishTheme.typography.body3R12,
+            color = CherrishTheme.colors.gray600
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CautionDescriptionPreview() {
+    CherrishTheme {
+        CautionDescription(
+            text = "본 정보는 인터넷 빅데이터 검색 및 분석을 통해 " +
+                "수집된 정보\n이며, 공식적인 의료 정보가 아닙니다."
+        )
+    }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
@@ -13,7 +13,6 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
 fun CautionDescription(
-    text: String,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -30,7 +29,8 @@ fun CautionDescription(
         Spacer(modifier = Modifier.size(4.dp))
 
         Text(
-            text = text,
+            text = "본 정보는 인터넷 빅데이터 검색 및 분석을 통해 " +
+                "수집된 정보\n이며, 공식적인 의료 정보가 아닙니다.",
             modifier = modifier,
             style = CherrishTheme.typography.body3R12,
             color = CherrishTheme.colors.gray600
@@ -42,9 +42,6 @@ fun CautionDescription(
 @Composable
 private fun CautionDescriptionPreview() {
     CherrishTheme {
-        CautionDescription(
-            text = "본 정보는 인터넷 빅데이터 검색 및 분석을 통해 " +
-                "수집된 정보\n이며, 공식적인 의료 정보가 아닙니다."
-        )
+        CautionDescription()
     }
 }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/CautionDescription.kt
@@ -21,7 +21,6 @@ fun CautionDescription(
     ) {
         Text(
             text = "◎",
-            modifier = modifier,
             style = CherrishTheme.typography.body3R12,
             color = CherrishTheme.colors.gray600
         )
@@ -31,7 +30,6 @@ fun CautionDescription(
         Text(
             text = "본 정보는 인터넷 빅데이터 검색 및 분석을 통해 " +
                 "수집된 정보\n이며, 공식적인 의료 정보가 아닙니다.",
-            modifier = modifier,
             style = CherrishTheme.typography.body3R12,
             color = CherrishTheme.colors.gray600
         )

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/ProcedureTitleSection.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/ProcedureTitleSection.kt
@@ -1,10 +1,9 @@
 package com.cherrish.android.presentation.calendar.procedure.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -16,8 +15,7 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
 fun ProcedureTitleSection(
-    procedureName: String,
-    modifier: Modifier = Modifier
+    procedureName: String
 ) {
     HorizontalDivider(
         thickness = 1.dp,
@@ -27,15 +25,14 @@ fun ProcedureTitleSection(
         modifier = Modifier
             .fillMaxWidth()
             .background(color = CherrishTheme.colors.gray100)
-            .padding(horizontal = 25.dp, vertical = 20.dp)
+            .padding(horizontal = 25.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Text(
             text = "$procedureName 관련 시술 리스트",
             style = CherrishTheme.typography.title1SB18,
             color = CherrishTheme.colors.gray1000
         )
-
-        Spacer(modifier = Modifier.height(4.dp))
 
         CautionDescription()
     }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/ProcedureTitleSection.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/ProcedureTitleSection.kt
@@ -1,0 +1,60 @@
+package com.cherrish.android.presentation.calendar.procedure.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun ProcedureTitleSection(
+    procedureName: String,
+    modifier: Modifier = Modifier
+) {
+    HorizontalDivider(
+        modifier = Modifier
+            .fillMaxWidth(),
+        thickness = 1.dp,
+        color = CherrishTheme.colors.gray500
+    )
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = CherrishTheme.colors.gray100)
+            .padding(horizontal = 25.dp, vertical = 20.dp)
+    ) {
+        Text(
+            text = "$procedureName 관련 시술 리스트",
+            style = CherrishTheme.typography.title1SB18,
+            color = CherrishTheme.colors.gray1000
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        CautionDescription()
+    }
+    HorizontalDivider(
+        modifier = Modifier
+            .fillMaxWidth(),
+        thickness = 1.dp,
+        color = CherrishTheme.colors.gray500
+    )
+}
+
+@Preview
+@Composable
+private fun ProcedureTitleSectionPreview() {
+    CherrishTheme {
+        ProcedureTitleSection(
+            procedureName = "색소 ∙ 잡티"
+        )
+    }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/ProcedureTitleSection.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/ProcedureTitleSection.kt
@@ -20,13 +20,11 @@ fun ProcedureTitleSection(
     modifier: Modifier = Modifier
 ) {
     HorizontalDivider(
-        modifier = Modifier
-            .fillMaxWidth(),
         thickness = 1.dp,
         color = CherrishTheme.colors.gray500
     )
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .background(color = CherrishTheme.colors.gray100)
             .padding(horizontal = 25.dp, vertical = 20.dp)
@@ -42,8 +40,6 @@ fun ProcedureTitleSection(
         CautionDescription()
     }
     HorizontalDivider(
-        modifier = Modifier
-            .fillMaxWidth(),
         thickness = 1.dp,
         color = CherrishTheme.colors.gray500
     )


### PR DESCRIPTION
## Related issue 🛠
- closed #40

## Work Description ✏️
 - 시술 필터링 뷰의 타이틀 섹션을 구현했습니다.

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/b072eb09-18ff-46ac-822c-bb12e7a4e887" width="360"/>

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
시술 리스트 타이틀 섹션을 구현햇슴둥 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캘린더의 시술 정보 화면에 중요한 주의사항을 명확히 보여주는 새 UI 컴포넌트 추가
  * 시술명을 강조하는 섹션 헤더에 상하 구분선과 회색 배경, 가독성 높은 타이포그래피 적용으로 시각적 구분 강화
  * 섹션 하단에 주의 문구를 함께 표시해 사용자가 핵심 안내를 빠르게 인지하도록 개선

<sub>✏️ Tip: 리뷰 설정에서 이 요약을 맞춤화할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->