### PR TITLE
[FEAT/#46] 시술 뷰 StepProgressBar 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -60,7 +60,7 @@ fun StepProgressBar(
 private fun StepSegment(
     targetProgress: Float,
     animate: Boolean,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     val progress by animateFloatAsState(
         targetValue = targetProgress.coerceIn(0f, 1f),

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -90,21 +90,23 @@ private fun StepSegment(
 @Preview(showBackground = true)
 @Composable
 private fun StepProgressBarPreview() {
-    var step by remember { mutableIntStateOf(0) }
+    CherrishTheme {
+        var step by remember { mutableIntStateOf(0) }
 
-    Column(modifier = Modifier.padding(24.dp)) {
-        StepProgressBar(
-            totalStep = 4,
-            currentStep = step
-        )
+        Column(modifier = Modifier.padding(24.dp)) {
+            StepProgressBar(
+                totalStep = 4,
+                currentStep = step
+            )
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Button(
-            onClick = { step = (step + 1).coerceAtMost(3) },
-            enabled = step < 3
-        ) {
-            Text(text = "다음")
+            Button(
+                onClick = { step = (step + 1).coerceAtMost(3) },
+                enabled = step < 3
+            ) {
+                Text(text = "다음")
+            }
         }
     }
 }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -101,8 +101,8 @@ private fun StepProgressBarPreview() {
         Spacer(modifier = Modifier.height(16.dp))
 
         Button(
-            onClick = { step = (step + 1).coerceAtMost(2) },
-            enabled = step < 2
+            onClick = { step = (step + 1).coerceAtMost(3) },
+            enabled = step < 3
         ) {
             Text(text = "다음")
         }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -30,16 +30,17 @@ private val FigmaGentleEasing = CubicBezierEasing(0.4f, 0.0f, 0.2f, 1.0f)
 
 @Composable
 fun StepProgressBar(
+    totalStep: Int,
     currentStep: Int,
     modifier: Modifier = Modifier
 ) {
-    val safeStep = currentStep.coerceIn(0, 2)
+    val safeStep = currentStep.coerceIn(0, totalStep - 1)
 
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        repeat(3) { index ->
+        repeat(totalStep) { index ->
             val target = when {
                 index < safeStep -> 1f
                 index == safeStep -> 1f
@@ -92,7 +93,10 @@ private fun StepProgressBarPreview() {
     var step by remember { mutableIntStateOf(0) }
 
     Column(modifier = Modifier.padding(24.dp)) {
-        StepProgressBar(currentStep = step)
+        StepProgressBar(
+            totalStep = 4,
+            currentStep = step
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -42,8 +42,7 @@ fun StepProgressBar(
     ) {
         repeat(totalStep) { index ->
             val target = when {
-                index < safeStep -> 1f
-                index == safeStep -> 1f
+                index <= safeStep -> 1f
                 else -> 0f
             }
 

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -64,7 +64,7 @@ private fun StepSegment(
     val progress by animateFloatAsState(
         targetValue = targetProgress.coerceIn(0f, 1f),
         animationSpec = if (animate) {
-            tween(durationMillis = 1200, easing = FigmaGentleEasing)
+            tween(durationMillis = 800, easing = FigmaGentleEasing)
         } else {
             tween(durationMillis = 0)
         }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/StepProgressBar.kt
@@ -1,0 +1,106 @@
+package com.cherrish.android.presentation.calendar.procedure.component
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+private val FigmaGentleEasing = CubicBezierEasing(0.4f, 0.0f, 0.2f, 1.0f)
+
+@Composable
+fun StepProgressBar(
+    currentStep: Int,
+    modifier: Modifier = Modifier
+) {
+    val safeStep = currentStep.coerceIn(0, 2)
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        repeat(3) { index ->
+            val target = when {
+                index < safeStep -> 1f
+                index == safeStep -> 1f
+                else -> 0f
+            }
+
+            StepSegment(
+                modifier = Modifier.weight(1f),
+                targetProgress = target,
+                animate = (index == safeStep)
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepSegment(
+    targetProgress: Float,
+    animate: Boolean,
+    modifier: Modifier
+) {
+    val progress by animateFloatAsState(
+        targetValue = targetProgress.coerceIn(0f, 1f),
+        animationSpec = if (animate) {
+            tween(durationMillis = 1200, easing = FigmaGentleEasing)
+        } else {
+            tween(durationMillis = 0)
+        }
+    )
+
+    Box(
+        modifier = modifier
+            .height(4.dp)
+            .clip(RoundedCornerShape(76.dp))
+            .background(CherrishTheme.colors.gray300)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress)
+                .height(4.dp)
+                .clip(RoundedCornerShape(76.dp))
+                .background(CherrishTheme.colors.gray800)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StepProgressBarPreview() {
+    var step by remember { mutableIntStateOf(0) }
+
+    Column(modifier = Modifier.padding(24.dp)) {
+        StepProgressBar(currentStep = step)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { step = (step + 1).coerceAtMost(2) },
+            enabled = step < 2
+        ) {
+            Text(text = "다음")
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #46 

## Work Description ✏️
 - 시술 선택 플로우의 progress bar를 구현했습니다.

## Screenshot 📸
| StepProgressBar | 
|:--:|
| <img width="300" src="https://github.com/user-attachments/assets/48829bf4-9341-48bf-85d4-7e4488f5e24d" /> | 

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
프로그레스 바 구현햇어요 뿌 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 다단계(총 단계 지정 가능) 분할형 진행 표시기를 추가했습니다. 각 세그먼트는 완료·진행·미진행 상태를 시각적으로 구분하며 현재 단계는 부드러운 애니메이션으로 채워집니다.
  * 미리보기에서 "다음" 버튼으로 단계를 전환해 애니메이션, 색상 테마 및 레이아웃 동작을 직접 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->