### PR TITLE
[FEAT/#51] 시술 선택 바텀시트 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -39,6 +40,7 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import com.cherrish.android.presentation.calendar.procedure.model.SelectedProcedureModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,7 +65,7 @@ fun SelectedProcedureBottomSheet(
 
     val configuration = LocalConfiguration.current
     val screenHeightDp = configuration.screenHeightDp.dp
-    val sheetHeight = screenHeightDp * 0.36f
+    val maxSheetHeight = screenHeightDp * 0.36f
     val listState = rememberLazyListState()
 
     val isFirstItemVisible = remember(selectedProcedure.size) {
@@ -100,12 +102,12 @@ fun SelectedProcedureBottomSheet(
             dragHandle = null
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(sheetHeight)
+                modifier = Modifier.fillMaxWidth()
             ) {
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = maxSheetHeight),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
@@ -129,7 +131,7 @@ fun SelectedProcedureBottomSheet(
                         state = listState,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .weight(1f)
+                            .weight(1f, fill = false)
                             .padding(horizontal = 24.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -210,61 +212,76 @@ fun SelectedProcedureBottomSheet(
 private fun SelectedProcedureBottomSheetPreview() {
     CherrishTheme {
         var isSheetVisible by remember { mutableStateOf(true) }
+        var selectedProcedures by remember {
+            mutableStateOf(
+                persistentListOf(
+                    SelectedProcedureModel(
+                        procedureId = 1L,
+                        procedureName = "레이저 토닝",
+                        minDowntimeDays = 3,
+                        maxDowntimeDays = 5
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 2L,
+                        procedureName = "보톡스",
+                        minDowntimeDays = 2,
+                        maxDowntimeDays = 4
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 3L,
+                        procedureName = "울쎄라",
+                        minDowntimeDays = 5,
+                        maxDowntimeDays = 7
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 4L,
+                        procedureName = "필러",
+                        minDowntimeDays = 3,
+                        maxDowntimeDays = 6
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 5L,
+                        procedureName = "리프팅 레이저",
+                        minDowntimeDays = 7,
+                        maxDowntimeDays = 10
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 6L,
+                        procedureName = "피코토닝",
+                        minDowntimeDays = 2,
+                        maxDowntimeDays = 4
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 7L,
+                        procedureName = "쥬베룩",
+                        minDowntimeDays = 4,
+                        maxDowntimeDays = 6
+                    ),
+                    SelectedProcedureModel(
+                        procedureId = 8L,
+                        procedureName = "스킨보톡스",
+                        minDowntimeDays = 2,
+                        maxDowntimeDays = 3
+                    )
+                )
+            )
+        }
 
         SelectedProcedureBottomSheet(
             isVisible = isSheetVisible,
-            selectedProcedure = persistentListOf(
-                SelectedProcedureModel(
-                    procedureId = 1L,
-                    procedureName = "레이저 토닝",
-                    minDowntimeDays = 3,
-                    maxDowntimeDays = 5
-                ),
-                SelectedProcedureModel(
-                    procedureId = 2L,
-                    procedureName = "보톡스",
-                    minDowntimeDays = 2,
-                    maxDowntimeDays = 4
-                ),
-                SelectedProcedureModel(
-                    procedureId = 3L,
-                    procedureName = "울쎄라",
-                    minDowntimeDays = 5,
-                    maxDowntimeDays = 7
-                ),
-                SelectedProcedureModel(
-                    procedureId = 4L,
-                    procedureName = "필러",
-                    minDowntimeDays = 3,
-                    maxDowntimeDays = 6
-                ),
-                SelectedProcedureModel(
-                    procedureId = 5L,
-                    procedureName = "리프팅 레이저",
-                    minDowntimeDays = 7,
-                    maxDowntimeDays = 10
-                ),
-                SelectedProcedureModel(
-                    procedureId = 6L,
-                    procedureName = "피코토닝",
-                    minDowntimeDays = 2,
-                    maxDowntimeDays = 4
-                ),
-                SelectedProcedureModel(
-                    procedureId = 7L,
-                    procedureName = "쥬베룩",
-                    minDowntimeDays = 4,
-                    maxDowntimeDays = 6
-                ),
-                SelectedProcedureModel(
-                    procedureId = 8L,
-                    procedureName = "스킨보톡스",
-                    minDowntimeDays = 2,
-                    maxDowntimeDays = 3
-                )
-            ),
+            selectedProcedure = selectedProcedures,
             onDismiss = { isSheetVisible = false },
-            onDeletedClick = {},
+            onDeletedClick = { procedureId ->
+                val newList = selectedProcedures
+                    .filter { it.procedureId != procedureId }
+                    .toPersistentList()
+
+                selectedProcedures = newList
+
+                if (newList.isEmpty()) {
+                    isSheetVisible = false
+                }
+            },
             onButtonClick = { isSheetVisible = false }
         )
     }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
@@ -1,0 +1,241 @@
+package com.cherrish.android.presentation.calendar.procedure.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.designsystem.component.button.CherrishButton
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.presentation.calendar.procedure.model.SelectedProcedureModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectedProcedureBottomSheet(
+    selectedProcedure: ImmutableList<SelectedProcedureModel>,
+    onDismiss: () -> Unit,
+    onDeletedClick: (Long) -> Unit,
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState()
+) {
+    val configuration = LocalConfiguration.current
+    val screenHeightDp = configuration.screenHeightDp.dp
+    val sheetHeight = screenHeightDp * 0.36f
+    val listState = rememberLazyListState()
+
+    val isFirstItemVisible = remember {
+        derivedStateOf {
+            val firstVisibleItem = listState.layoutInfo.visibleItemsInfo.firstOrNull()
+            firstVisibleItem?.index == 0
+        }
+    }
+
+    val isLastItemVisible = remember {
+        derivedStateOf {
+            val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            val lastItemIndex = selectedProcedure.size - 1
+            lastVisibleItem?.index == lastItemIndex
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier.fillMaxWidth(),
+        containerColor = CherrishTheme.colors.gray0,
+        shape = RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp),
+        dragHandle = null
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(sheetHeight)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "선택한 시술",
+                    color = CherrishTheme.colors.gray600,
+                    style = CherrishTheme.typography.body1SB14,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 9.dp, horizontal = 24.dp),
+                    textAlign = TextAlign.Start
+                )
+
+                HorizontalDivider(
+                    thickness = 1.dp,
+                    color = CherrishTheme.colors.gray400
+                )
+
+                Spacer(modifier = Modifier.height(14.dp))
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .padding(horizontal = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(
+                        items = selectedProcedure,
+                        key = { it.procedureId }
+                    ) { procedure ->
+                        SelectedProcedureItem(
+                            procedureId = procedure.procedureId,
+                            procedureName = procedure.procedureName,
+                            minDowntimeDays = procedure.minDowntimeDays,
+                            maxDowntimeDays = procedure.maxDowntimeDays,
+                            onDeletedClick = { onDeletedClick(procedure.procedureId) }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(14.dp))
+
+                CherrishButton(
+                    text = "다음",
+                    onClick = onButtonClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(bottom = 20.dp)
+                )
+            }
+
+            if (!isFirstItemVisible.value) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .fillMaxWidth()
+                        .padding(top = 49.dp)
+                        .height(70.dp)
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    CherrishTheme.colors.gray0,
+                                    CherrishTheme.colors.gray0.copy(alpha = 0.8f),
+                                    CherrishTheme.colors.gray0.copy(alpha = 0.5f),
+                                    Color.Transparent
+                                )
+                            )
+                        )
+                )
+            }
+
+            if (!isLastItemVisible.value) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(bottom = 68.dp)
+                        .height(70.dp)
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    Color.Transparent,
+                                    CherrishTheme.colors.gray0.copy(alpha = 0.5f),
+                                    CherrishTheme.colors.gray0.copy(alpha = 0.8f),
+                                    CherrishTheme.colors.gray0
+                                )
+                            )
+                        )
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+private fun SelectedProcedureBottomSheetPreview() {
+    CherrishTheme {
+        SelectedProcedureBottomSheet(
+            selectedProcedure = persistentListOf(
+                SelectedProcedureModel(
+                    procedureId = 1L,
+                    procedureName = "레이저 토닝",
+                    minDowntimeDays = 3,
+                    maxDowntimeDays = 5
+                ),
+                SelectedProcedureModel(
+                    procedureId = 2L,
+                    procedureName = "보톡스",
+                    minDowntimeDays = 2,
+                    maxDowntimeDays = 4
+                ),
+                SelectedProcedureModel(
+                    procedureId = 3L,
+                    procedureName = "울쎄라",
+                    minDowntimeDays = 5,
+                    maxDowntimeDays = 7
+                ),
+                SelectedProcedureModel(
+                    procedureId = 4L,
+                    procedureName = "필러",
+                    minDowntimeDays = 3,
+                    maxDowntimeDays = 6
+                ),
+                SelectedProcedureModel(
+                    procedureId = 5L,
+                    procedureName = "리프팅 레이저",
+                    minDowntimeDays = 7,
+                    maxDowntimeDays = 10
+                ),
+                SelectedProcedureModel(
+                    procedureId = 6L,
+                    procedureName = "피코토닝",
+                    minDowntimeDays = 2,
+                    maxDowntimeDays = 4
+                ),
+                SelectedProcedureModel(
+                    procedureId = 7L,
+                    procedureName = "쥬베룩",
+                    minDowntimeDays = 4,
+                    maxDowntimeDays = 6
+                ),
+                SelectedProcedureModel(
+                    procedureId = 8L,
+                    procedureName = "스킨보톡스",
+                    minDowntimeDays = 2,
+                    maxDowntimeDays = 3
+                )
+            ),
+            onDismiss = {},
+            onDeletedClick = {},
+            onButtonClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
@@ -19,8 +19,12 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -39,26 +43,37 @@ import kotlinx.collections.immutable.persistentListOf
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelectedProcedureBottomSheet(
+    isVisible: Boolean,
     selectedProcedure: ImmutableList<SelectedProcedureModel>,
     onDismiss: () -> Unit,
     onDeletedClick: (Long) -> Unit,
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState()
+    sheetState: SheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
 ) {
+    LaunchedEffect(isVisible) {
+        if (isVisible) {
+            sheetState.show()
+        } else {
+            sheetState.hide()
+        }
+    }
+
     val configuration = LocalConfiguration.current
     val screenHeightDp = configuration.screenHeightDp.dp
     val sheetHeight = screenHeightDp * 0.36f
     val listState = rememberLazyListState()
 
-    val isFirstItemVisible = remember {
+    val isFirstItemVisible = remember(selectedProcedure.size) {
         derivedStateOf {
             val firstVisibleItem = listState.layoutInfo.visibleItemsInfo.firstOrNull()
             firstVisibleItem?.index == 0
         }
     }
 
-    val isLastItemVisible = remember {
+    val isLastItemVisible = remember(selectedProcedure.size) {
         derivedStateOf {
             val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()
             val lastItemIndex = selectedProcedure.size - 1
@@ -66,18 +81,12 @@ fun SelectedProcedureBottomSheet(
         }
     }
 
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        modifier = modifier.fillMaxWidth(),
-        containerColor = CherrishTheme.colors.gray0,
-        shape = RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp),
-        dragHandle = null
-    ) {
-        Box(
-            modifier = Modifier
+    if (sheetState.isVisible) {
+        ModalBottomSheet(
+            onDismissRequest = onDismiss,
+            sheetState = sheetState,
+            modifier = modifier
                 .fillMaxWidth()
-                .height(sheetHeight)
                 .dropShadow(
                     shape = RoundedCornerShape(10.dp),
                     color = CherrishTheme.colors.shadow,
@@ -85,102 +94,111 @@ fun SelectedProcedureBottomSheet(
                     offsetX = 0.dp,
                     offsetY = 0.dp,
                     spread = 0.dp
-                )
+                ),
+            containerColor = CherrishTheme.colors.gray0,
+            shape = RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp),
+            dragHandle = null
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(sheetHeight)
             ) {
-                Text(
-                    text = "선택한 시술",
-                    color = CherrishTheme.colors.gray600,
-                    style = CherrishTheme.typography.body1SB14,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 9.dp, horizontal = 24.dp),
-                    textAlign = TextAlign.Start
-                )
-
-                HorizontalDivider(
-                    thickness = 1.dp,
-                    color = CherrishTheme.colors.gray400
-                )
-
-                Spacer(modifier = Modifier.height(14.dp))
-
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .padding(horizontal = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    items(
-                        items = selectedProcedure,
-                        key = { it.procedureId }
-                    ) { procedure ->
-                        SelectedProcedureItem(
-                            procedureId = procedure.procedureId,
-                            procedureName = procedure.procedureName,
-                            minDowntimeDays = procedure.minDowntimeDays,
-                            maxDowntimeDays = procedure.maxDowntimeDays,
-                            onDeletedClick = { onDeletedClick(procedure.procedureId) }
-                        )
+                    Text(
+                        text = "선택한 시술",
+                        color = CherrishTheme.colors.gray600,
+                        style = CherrishTheme.typography.body1SB14,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 9.dp, horizontal = 24.dp),
+                        textAlign = TextAlign.Start
+                    )
+
+                    HorizontalDivider(
+                        thickness = 1.dp,
+                        color = CherrishTheme.colors.gray400
+                    )
+
+                    Spacer(modifier = Modifier.height(14.dp))
+
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .padding(horizontal = 24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(
+                            items = selectedProcedure,
+                            key = { it.procedureId }
+                        ) { procedure ->
+                            SelectedProcedureItem(
+                                procedureId = procedure.procedureId,
+                                procedureName = procedure.procedureName,
+                                minDowntimeDays = procedure.minDowntimeDays,
+                                maxDowntimeDays = procedure.maxDowntimeDays,
+                                onDeletedClick = { onDeletedClick(procedure.procedureId) }
+                            )
+                        }
                     }
+
+                    Spacer(modifier = Modifier.height(14.dp))
+
+                    CherrishButton(
+                        text = "다음",
+                        onClick = onButtonClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp)
+                            .padding(bottom = 20.dp)
+                    )
                 }
 
-                Spacer(modifier = Modifier.height(14.dp))
-
-                CherrishButton(
-                    text = "다음",
-                    onClick = onButtonClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp)
-                        .padding(bottom = 20.dp)
-                )
-            }
-
-            if (!isFirstItemVisible.value) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .fillMaxWidth()
-                        .padding(top = 49.dp)
-                        .height(70.dp)
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    CherrishTheme.colors.gray0,
-                                    CherrishTheme.colors.gray0.copy(alpha = 0.8f),
-                                    CherrishTheme.colors.gray0.copy(alpha = 0.5f),
-                                    Color.Transparent
+                if (!isFirstItemVisible.value) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .fillMaxWidth()
+                            .padding(top = 49.dp)
+                            .height(70.dp)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        CherrishTheme.colors.gray0,
+                                        CherrishTheme.colors.gray0.copy(alpha = 0.8f),
+                                        CherrishTheme.colors.gray0.copy(alpha = 0.5f),
+                                        Color.Transparent
+                                    )
                                 )
                             )
-                        )
-                )
-            }
+                    )
+                }
 
-            if (!isLastItemVisible.value) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth()
-                        .padding(bottom = 68.dp)
-                        .height(70.dp)
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    CherrishTheme.colors.gray0.copy(alpha = 0.5f),
-                                    CherrishTheme.colors.gray0.copy(alpha = 0.8f),
-                                    CherrishTheme.colors.gray0
+                if (!isLastItemVisible.value) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
+                            .padding(bottom = 68.dp)
+                            .height(70.dp)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        Color.Transparent,
+                                        CherrishTheme.colors.gray0.copy(alpha = 0.5f),
+                                        CherrishTheme.colors.gray0.copy(alpha = 0.8f),
+                                        CherrishTheme.colors.gray0
+                                    )
                                 )
                             )
-                        )
-                )
+                    )
+                }
             }
         }
     }
@@ -191,7 +209,10 @@ fun SelectedProcedureBottomSheet(
 @Composable
 private fun SelectedProcedureBottomSheetPreview() {
     CherrishTheme {
+        var isSheetVisible by remember { mutableStateOf(true) }
+
         SelectedProcedureBottomSheet(
+            isVisible = isSheetVisible,
             selectedProcedure = persistentListOf(
                 SelectedProcedureModel(
                     procedureId = 1L,
@@ -242,9 +263,9 @@ private fun SelectedProcedureBottomSheetPreview() {
                     maxDowntimeDays = 3
                 )
             ),
-            onDismiss = {},
+            onDismiss = { isSheetVisible = false },
             onDeletedClick = {},
-            onButtonClick = {}
+            onButtonClick = { isSheetVisible = false }
         )
     }
 }

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cherrish.android.core.common.extension.dropShadow
@@ -117,7 +116,7 @@ fun SelectedProcedureBottomSheet(
                         style = CherrishTheme.typography.body1SB14,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 9.dp, horizontal = 24.dp),
+                            .padding(vertical = 9.dp, horizontal = 24.dp)
                     )
 
                     HorizontalDivider(

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -117,7 +118,6 @@ fun SelectedProcedureBottomSheet(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 9.dp, horizontal = 24.dp),
-                        textAlign = TextAlign.Start
                     )
 
                     HorizontalDivider(
@@ -125,14 +125,13 @@ fun SelectedProcedureBottomSheet(
                         color = CherrishTheme.colors.gray400
                     )
 
-                    Spacer(modifier = Modifier.height(14.dp))
-
                     LazyColumn(
                         state = listState,
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f, fill = false)
                             .padding(horizontal = 24.dp),
+                        contentPadding = PaddingValues(top = 14.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureBottomSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.cherrish.android.core.common.extension.dropShadow
 import com.cherrish.android.core.designsystem.component.button.CherrishButton
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import com.cherrish.android.presentation.calendar.procedure.model.SelectedProcedureModel
@@ -77,6 +78,14 @@ fun SelectedProcedureBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(sheetHeight)
+                .dropShadow(
+                    shape = RoundedCornerShape(10.dp),
+                    color = CherrishTheme.colors.shadow,
+                    blur = 10.dp,
+                    offsetX = 0.dp,
+                    offsetY = 0.dp,
+                    spread = 0.dp
+                )
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureItem.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -30,20 +31,19 @@ fun SelectedProcedureItem(
     onDeletedClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier
+    Row(
+        modifier = modifier
             .fillMaxWidth()
             .clip(shape = RoundedCornerShape(6.dp))
             .background(color = CherrishTheme.colors.gray200)
-            .padding(horizontal = 11.dp)
+            .padding(horizontal = 11.dp, vertical = 5.dp),
+        verticalAlignment = CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
         SelectedProcedureTitle(
             procedureName = procedureName,
             minDowntimeDays = minDowntimeDays,
             maxDowntimeDays = maxDowntimeDays,
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .padding(vertical = 7.dp)
         )
 
         Icon(
@@ -51,9 +51,8 @@ fun SelectedProcedureItem(
             contentDescription = null,
             tint = CherrishTheme.colors.gray600,
             modifier = Modifier
-                .align(Alignment.CenterEnd)
                 .noRippleClickable(onClick = { onDeletedClick(procedureId) })
-                .padding(vertical = 5.dp)
+
         )
     }
 }
@@ -66,9 +65,8 @@ private fun SelectedProcedureTitle(
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+        verticalAlignment = CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text(

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureItem.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureItem.kt
@@ -2,7 +2,6 @@ package com.cherrish.android.presentation.calendar.procedure.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,7 +9,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,7 +41,7 @@ fun SelectedProcedureItem(
         SelectedProcedureTitle(
             procedureName = procedureName,
             minDowntimeDays = minDowntimeDays,
-            maxDowntimeDays = maxDowntimeDays,
+            maxDowntimeDays = maxDowntimeDays
         )
 
         Icon(

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureItem.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/component/SelectedProcedureItem.kt
@@ -1,0 +1,106 @@
+package com.cherrish.android.presentation.calendar.procedure.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.R
+import com.cherrish.android.core.common.extension.noRippleClickable
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun SelectedProcedureItem(
+    procedureId: Long,
+    procedureName: String,
+    minDowntimeDays: Int,
+    maxDowntimeDays: Int,
+    onDeletedClick: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier
+            .fillMaxWidth()
+            .clip(shape = RoundedCornerShape(6.dp))
+            .background(color = CherrishTheme.colors.gray200)
+            .padding(horizontal = 11.dp)
+    ) {
+        SelectedProcedureTitle(
+            procedureName = procedureName,
+            minDowntimeDays = minDowntimeDays,
+            maxDowntimeDays = maxDowntimeDays,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(vertical = 7.dp)
+        )
+
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_deletebox),
+            contentDescription = null,
+            tint = CherrishTheme.colors.gray600,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .noRippleClickable(onClick = { onDeletedClick(procedureId) })
+                .padding(vertical = 5.dp)
+        )
+    }
+}
+
+@Composable
+private fun SelectedProcedureTitle(
+    procedureName: String,
+    minDowntimeDays: Int,
+    maxDowntimeDays: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = procedureName,
+            color = CherrishTheme.colors.gray800,
+            style = CherrishTheme.typography.body1R14
+        )
+
+        Text(
+            text = "|",
+            color = CherrishTheme.colors.gray600,
+            style = CherrishTheme.typography.body2R13
+        )
+
+        Text(
+            text = "다운타임* $minDowntimeDays-$maxDowntimeDays",
+            color = CherrishTheme.colors.gray700,
+            style = CherrishTheme.typography.body1R14
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SelectedProcedureItemPreview() {
+    CherrishTheme {
+        SelectedProcedureItem(
+            procedureId = 1,
+            procedureName = "레이저 토닝",
+            minDowntimeDays = 3,
+            maxDowntimeDays = 5,
+            onDeletedClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/model/SelectedProcedureModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/calendar/procedure/model/SelectedProcedureModel.kt
@@ -1,0 +1,11 @@
+package com.cherrish.android.presentation.calendar.procedure.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class SelectedProcedureModel(
+    val procedureId: Long,
+    val procedureName: String,
+    val minDowntimeDays: Int,
+    val maxDowntimeDays: Int
+)

--- a/app/src/main/res/drawable/ic_deletebox.xml
+++ b/app/src/main/res/drawable/ic_deletebox.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7,5.6L17,5.6A1.4,1.4 0,0 1,18.4 7L18.4,17A1.4,1.4 0,0 1,17 18.4L7,18.4A1.4,1.4 0,0 1,5.6 17L5.6,7A1.4,1.4 0,0 1,7 5.6z"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#9FA4A9"/>
+  <path
+      android:pathData="M9.126,9.126C9.293,8.958 9.564,8.958 9.732,9.126L12,11.394L14.268,9.126C14.436,8.958 14.707,8.958 14.875,9.126C15.042,9.293 15.042,9.564 14.875,9.732L12.606,12L14.875,14.268C15.042,14.436 15.042,14.707 14.875,14.875C14.707,15.042 14.436,15.042 14.268,14.875L12,12.606L9.732,14.875C9.564,15.042 9.293,15.042 9.126,14.875C8.958,14.707 8.958,14.436 9.126,14.268L11.394,12L9.126,9.732C8.958,9.564 8.958,9.293 9.126,9.126Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.2"
+      android:fillColor="#9FA4A9"
+      android:strokeColor="#9FA4A9"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #51 

## Work Description ✏️
 - 시술 선택 바텀시트를 구현했어요.



## Screenshot 📸
<img width="265" height="560" alt="image" src="https://github.com/user-attachments/assets/23a70eee-3f6c-48f0-84a4-b1eb015e1f28" />


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
시술 선택 바텀시트를 구현했어요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 선택한 시술을 보여주는 모달 하단 시트 추가: 전체 너비, 둥근 모서리, 헤더("선택한 시술"), 스크롤 가능한 목록, 항목 삭제 및 "다음" 버튼 제공.
* 각 시술을 표시하는 캡슐형 항목 컴포저블 추가: 시술명·다운타임 범위 표기와 삭제 액션 포함.
* 선택된 시술을 표현하는 불변 데이터 모델 추가.
* 삭제 아이콘 벡터 자원(ic_deletebox) 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->