### PR TITLE
[FEAT/#48] 마이페이지 뷰 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/mypage/component/MyPageHeader.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/mypage/component/MyPageHeader.kt
@@ -1,11 +1,10 @@
 package com.cherrish.android.presentation.mypage.component
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -29,15 +28,14 @@ fun MyPageHeader(
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(space = 14.dp)
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = profileIcon),
             contentDescription = null,
             modifier = Modifier.clip(CircleShape)
         )
-
-        Spacer(modifier = Modifier.width(width = 14.dp))
 
         Column(
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/cherrish/android/presentation/mypage/component/MyPageHeader.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/mypage/component/MyPageHeader.kt
@@ -21,7 +21,7 @@ import com.cherrish.android.R
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
-fun MypageHeader(
+fun MyPageHeader(
     @DrawableRes profileIcon: Int,
     nicknameText: String,
     skinCareDay: Int,
@@ -59,8 +59,8 @@ fun MypageHeader(
 
 @Preview(showBackground = true)
 @Composable
-private fun MypageHeaderPreview() {
-    MypageHeader(
+private fun MyPageHeaderPreview() {
+    MyPageHeader(
         profileIcon = R.drawable.ic_launcher_foreground,
         nicknameText = "김체체",
         skinCareDay = 13

--- a/app/src/main/java/com/cherrish/android/presentation/mypage/component/MypageHeader.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/mypage/component/MypageHeader.kt
@@ -1,0 +1,64 @@
+package com.cherrish.android.presentation.mypage.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cherrish.android.R
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+
+@Composable
+fun MypageHeader(
+    profileIcon: Int, nicknameText: String, skinCareDay: Int, modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+
+        Icon(
+            imageVector = ImageVector.vectorResource(id = profileIcon),
+            contentDescription = "ProfileImage",
+            modifier = Modifier.clip(CircleShape),
+        )
+
+        Spacer(Modifier.width(width = 14.dp))
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+
+            Text(
+                text = "안녕하세요, $nicknameText 님",
+                modifier = Modifier,
+                color = CherrishTheme.colors.gray1000,
+                style = CherrishTheme.typography.title1SB18
+            )
+
+            Text(
+                text = "관리 시작 D+ $skinCareDay",
+                modifier = Modifier,
+                color = CherrishTheme.colors.gray800,
+                style = CherrishTheme.typography.body1M14
+            )
+
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyPageHeaderPreview() {
+    MypageHeader(
+        profileIcon = R.drawable.ic_launcher_foreground,
+        nicknameText = "김체체",
+        skinCareDay = 13
+    )
+}

--- a/app/src/main/java/com/cherrish/android/presentation/mypage/component/MypageHeader.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/mypage/component/MypageHeader.kt
@@ -21,20 +21,26 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
 fun MypageHeader(
-    profileIcon: Int, nicknameText: String, skinCareDay: Int, modifier: Modifier = Modifier
+    profileIcon: Int,
+    nicknameText: String,
+    skinCareDay: Int,
+    modifier: Modifier = Modifier
 ) {
-    Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = profileIcon),
             contentDescription = "ProfileImage",
-            modifier = Modifier.clip(CircleShape),
+            modifier = Modifier.clip(CircleShape)
         )
 
-        Spacer(Modifier.width(width = 14.dp))
+        Spacer(modifier = Modifier.width(width = 14.dp))
 
-        Column(modifier = Modifier.fillMaxWidth()) {
-
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
             Text(
                 text = "안녕하세요, $nicknameText 님",
                 modifier = Modifier,
@@ -48,7 +54,6 @@ fun MypageHeader(
                 color = CherrishTheme.colors.gray800,
                 style = CherrishTheme.typography.body1M14
             )
-
         }
     }
 }

--- a/app/src/main/java/com/cherrish/android/presentation/mypage/component/MypageHeader.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/mypage/component/MypageHeader.kt
@@ -1,5 +1,6 @@
 package com.cherrish.android.presentation.mypage.component
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -21,7 +22,7 @@ import com.cherrish.android.core.designsystem.theme.CherrishTheme
 
 @Composable
 fun MypageHeader(
-    profileIcon: Int,
+    @DrawableRes profileIcon: Int,
     nicknameText: String,
     skinCareDay: Int,
     modifier: Modifier = Modifier
@@ -32,7 +33,7 @@ fun MypageHeader(
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = profileIcon),
-            contentDescription = "ProfileImage",
+            contentDescription = null,
             modifier = Modifier.clip(CircleShape)
         )
 
@@ -43,14 +44,12 @@ fun MypageHeader(
         ) {
             Text(
                 text = "안녕하세요, $nicknameText 님",
-                modifier = Modifier,
                 color = CherrishTheme.colors.gray1000,
                 style = CherrishTheme.typography.title1SB18
             )
 
             Text(
-                text = "관리 시작 D+ $skinCareDay",
-                modifier = Modifier,
+                text = "관리 시작 D + $skinCareDay",
                 color = CherrishTheme.colors.gray800,
                 style = CherrishTheme.typography.body1M14
             )
@@ -60,7 +59,7 @@ fun MypageHeader(
 
 @Preview(showBackground = true)
 @Composable
-private fun MyPageHeaderPreview() {
+private fun MypageHeaderPreview() {
     MypageHeader(
         profileIcon = R.drawable.ic_launcher_foreground,
         nicknameText = "김체체",


### PR DESCRIPTION
## Related issue 🛠
- closed #48 

## Work Description ✏️
 - 마이페이지 상단 Header 컴포넌트 구현
 - 상태/로직 없이 정적 UI 컴포넌트로 분리 
 - 프리뷰 구현
 - ktLint 실행 

## Screenshot 📸
<img width="612" height="200" alt="image" src="https://github.com/user-attachments/assets/b26f8e56-9010-4a01-b8dd-0398eef41fa8" />

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
body는 Screen 단에서 처리할 예정이라, Header만 컴포넌트로 분리해 작업했습니다 ! 상태는 따로 포함하지 않고, 정적으로 구현해봤습니다 !! 
이미지를 확장하려고 상위에서 주입받는 구조로 설계하려고 했습니다 ~~! !  그리고 네이밍이 조금 적절하지 않은 것 같기두 해서 ,, 한 번 코드 읽어봐주시고 편히 피드백 해주쎄용 ~~~~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지에 사용자 프로필 헤더 추가: 원형 프로필 아이콘, 닉네임을 포함한 개인화 인사말 및 스킨케어 관리 경과일(D+) 표시를 제공하여 마이페이지를 더 직관적으로 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->