### PR TITLE
[FIX#81] 투두 리스트 컴포넌트 터치 영역 수정

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeChecklist.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeChecklist.kt
@@ -52,13 +52,13 @@ fun ChallengeChecklist(
                 color = CherrishTheme.colors.gray500,
                 shape = RoundedCornerShape(10.dp)
             )
+            .noRippleClickable(onClick = onChecklistClick)
             .background(color = CherrishTheme.colors.gray0)
             .padding(vertical = 12.dp)
             .padding(start = 14.dp)
     ) {
         ChallengeChecklistItem(
             checklistIcon = checklistIcon,
-            onChecklistClick = onChecklistClick,
             checklistContent = checklistContent,
             contentColor = contentColor,
             contentDecoration = contentDecoration
@@ -69,7 +69,6 @@ fun ChallengeChecklist(
 @Composable
 private fun ChallengeChecklistItem(
     @DrawableRes checklistIcon: Int,
-    onChecklistClick: () -> Unit,
     checklistContent: String,
     contentColor: Color,
     contentDecoration: TextDecoration,
@@ -83,9 +82,6 @@ private fun ChallengeChecklistItem(
         Icon(
             imageVector = ImageVector.vectorResource(id = checklistIcon),
             contentDescription = null,
-            modifier = Modifier.noRippleClickable(
-                onClick = onChecklistClick
-            ),
             tint = Color.Unspecified
         )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #81 

## Work Description ✏️
 - 투두 리스트 컴포넌트 터치 영역 수정


## Screenshot 📸
https://github.com/user-attachments/assets/169ccac6-705c-4bf8-961a-1d87387105e9

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
터치 영역 수정햇슴 !!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 체크리스트 항목의 상호작용 개선: 전체 행을 클릭하여 체크리스트 항목을 선택할 수 있도록 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->