### PR TITLE
[FEAT/#42] 챌린지 루틴 선택 뷰 스크린 구현 

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -47,7 +47,7 @@ fun ChallengeRoutineRoute(
                 paddingValues = paddingValues,
                 onRoutineClick = viewModel::onRoutineClick,
                 onNextClick = viewModel::onNextClick,
-                onBackClick = viewModel::onBackCLick,
+                onBackClick = viewModel::onBackClick,
                 onCloseClick = viewModel::onCloseClick
             )
         }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -17,7 +18,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.cherrish.android.core.common.state.UiState
 import com.cherrish.android.core.designsystem.component.button.CherrishButton
 import com.cherrish.android.core.designsystem.component.topappbar.BackAndCloseTopAppBar
@@ -66,7 +66,7 @@ private fun ChallengeRoutineScreen(
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val hasSelected = uiState.routines.any { it.isSelected }
+    val isSelected = uiState.routines.any { it.isSelected }
 
     Column(
         modifier = modifier
@@ -75,7 +75,7 @@ private fun ChallengeRoutineScreen(
             .padding(paddingValues)
             .navigationBarsPadding()
     ) {
-        Spacer(Modifier.weight(44f))
+        Spacer(Modifier.height(44.dp))
 
         BackAndCloseTopAppBar(
             title = "루틴 챌린지 선택",
@@ -95,12 +95,12 @@ private fun ChallengeRoutineScreen(
 
         CherrishButton(
             text = "다음",
-            enabled = hasSelected,
+            enabled = isSelected,
             onClick = onNextClick,
             modifier = Modifier.padding(horizontal = 24.dp)
         )
 
-        Spacer(Modifier.weight(30f))
+        Spacer(Modifier.height(30.dp))
     }
 }
 

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -69,6 +69,8 @@ private fun ChallengeRoutineScreen(
             .background(CherrishTheme.colors.gray0)
             .padding(paddingValues)
     ) {
+        Spacer(Modifier.weight(44f))
+
         BackAndCloseTopAppBar(
             title = "루틴 챌린지 선택",
             onBackClick = onBackClick,

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -34,17 +34,21 @@ fun ChallengeRoutineRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    when (uiState) {
-        is UiState.Loading -> Unit
-        is UiState.Failure -> Unit
+    when (val state = uiState) {
+        is UiState.Loading -> {
+        }
+
+        is UiState.Failure -> {
+        }
+
         is UiState.Success -> {
             ChallengeRoutineScreen(
+                uiState = state.data,
                 paddingValues = paddingValues,
-                uiState = (uiState as UiState.Success<ChallengeRoutineUiState>).data,
                 onRoutineClick = viewModel::onRoutineClick,
                 onNextClick = viewModel::onNextClick,
-                onBackClick = {},
-                onCloseClick = {}
+                onBackClick = viewModel::onBackCLick,
+                onCloseClick = viewModel::onCloseClick
             )
         }
 

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -68,6 +69,7 @@ private fun ChallengeRoutineScreen(
             .fillMaxSize()
             .background(CherrishTheme.colors.gray0)
             .padding(paddingValues)
+            .navigationBarsPadding()
     ) {
         Spacer(Modifier.weight(44f))
 

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -19,15 +18,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.cherrish.android.core.common.state.UiState
-import com.cherrish.android.core.common.state.UiState.*
 import com.cherrish.android.core.designsystem.component.button.CherrishButton
 import com.cherrish.android.core.designsystem.component.topappbar.BackAndCloseTopAppBar
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
-import com.cherrish.android.presentation.challenge.component.ChallengeMissionOnboardingBody
 import com.cherrish.android.presentation.challenge.component.ChallengeRoutineOnboardingBody
-import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
 import com.cherrish.android.presentation.challenge.routine.model.ChallengeRoutineModel
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 
@@ -44,7 +39,7 @@ fun ChallengeRoutineRoute(
         is UiState.Success -> {
             ChallengeRoutineScreen(
                 paddingValues = paddingValues,
-                uiState = (uiState as Success<ChallengeRoutineUiState>).data,
+                uiState = (uiState as UiState.Success<ChallengeRoutineUiState>).data,
                 onRoutineClick = viewModel::onRoutineClick,
                 onNextClick = viewModel::onNextClick,
                 onBackClick = {},
@@ -87,7 +82,9 @@ private fun ChallengeRoutineScreen(
             onItemClick = onRoutineClick,
             modifier = Modifier.padding(horizontal = 26.dp)
         )
+
         Spacer(Modifier.weight(232f))
+
         CherrishButton(
             text = "다음",
             enabled = hasSelected,
@@ -96,15 +93,12 @@ private fun ChallengeRoutineScreen(
         )
 
         Spacer(Modifier.weight(30f))
-
     }
 }
-
 
 @Preview(showBackground = true)
 @Composable
 private fun ChallengeRoutineScreenDisabledPreview() {
-
     var uiState by remember {
         mutableStateOf(
             ChallengeRoutineUiState(
@@ -117,6 +111,7 @@ private fun ChallengeRoutineScreenDisabledPreview() {
             )
         )
     }
+
     ChallengeRoutineScreen(
         paddingValues = PaddingValues(),
         uiState = uiState,

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineScreen.kt
@@ -1,0 +1,134 @@
+package com.cherrish.android.presentation.challenge.routine
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.cherrish.android.core.common.state.UiState
+import com.cherrish.android.core.common.state.UiState.*
+import com.cherrish.android.core.designsystem.component.button.CherrishButton
+import com.cherrish.android.core.designsystem.component.topappbar.BackAndCloseTopAppBar
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.presentation.challenge.component.ChallengeMissionOnboardingBody
+import com.cherrish.android.presentation.challenge.component.ChallengeRoutineOnboardingBody
+import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
+import com.cherrish.android.presentation.challenge.routine.model.ChallengeRoutineModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+
+@Composable
+fun ChallengeRoutineRoute(
+    paddingValues: PaddingValues,
+    viewModel: ChallengeRoutineViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (uiState) {
+        is UiState.Loading -> Unit
+        is UiState.Failure -> Unit
+        is UiState.Success -> {
+            ChallengeRoutineScreen(
+                paddingValues = paddingValues,
+                uiState = (uiState as Success<ChallengeRoutineUiState>).data,
+                onRoutineClick = viewModel::onRoutineClick,
+                onNextClick = viewModel::onNextClick,
+                onBackClick = {},
+                onCloseClick = {}
+            )
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun ChallengeRoutineScreen(
+    paddingValues: PaddingValues,
+    uiState: ChallengeRoutineUiState,
+    onRoutineClick: (Long) -> Unit,
+    onNextClick: () -> Unit,
+    onBackClick: () -> Unit,
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hasSelected = uiState.routines.any { it.isSelected }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(CherrishTheme.colors.gray0)
+            .padding(paddingValues)
+    ) {
+        BackAndCloseTopAppBar(
+            title = "루틴 챌린지 선택",
+            onBackClick = onBackClick,
+            onCloseClick = onCloseClick
+        )
+
+        Spacer(Modifier.weight(70f))
+
+        ChallengeRoutineOnboardingBody(
+            items = uiState.routines,
+            onItemClick = onRoutineClick,
+            modifier = Modifier.padding(horizontal = 26.dp)
+        )
+        Spacer(Modifier.weight(232f))
+        CherrishButton(
+            text = "다음",
+            enabled = hasSelected,
+            onClick = onNextClick,
+            modifier = Modifier.padding(horizontal = 24.dp)
+        )
+
+        Spacer(Modifier.weight(30f))
+
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun ChallengeRoutineScreenDisabledPreview() {
+
+    var uiState by remember {
+        mutableStateOf(
+            ChallengeRoutineUiState(
+                routines = persistentListOf(
+                    ChallengeRoutineModel(1L, "피부 컨디션"),
+                    ChallengeRoutineModel(2L, "생활 습관"),
+                    ChallengeRoutineModel(3L, "체형 관리"),
+                    ChallengeRoutineModel(4L, "웰니스 · 마음챙김")
+                )
+            )
+        )
+    }
+    ChallengeRoutineScreen(
+        paddingValues = PaddingValues(),
+        uiState = uiState,
+        onRoutineClick = { id ->
+            uiState = uiState.copy(
+                routines = uiState.routines.map {
+                    it.copy(isSelected = it.id == id)
+                }.toPersistentList()
+            )
+        },
+        onNextClick = {},
+        onBackClick = {},
+        onCloseClick = {}
+    )
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineUiState.kt
@@ -1,17 +1,10 @@
 package com.cherrish.android.presentation.challenge.routine
 
 import androidx.compose.runtime.Immutable
+import com.cherrish.android.presentation.challenge.routine.model.ChallengeRoutineModel
+import kotlinx.collections.immutable.ImmutableList
 
 @Immutable
 data class ChallengeRoutineUiState(
-    val routine: String = "",
-    val isSelected: Boolean = false
-) {
-    companion object {
-        val FakeRoutine =
-            ChallengeRoutineUiState(
-                routine = "피부 컨디션",
-                isSelected = false
-            )
-    }
-}
+    val routines: ImmutableList<ChallengeRoutineModel>
+)

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineUiState.kt
@@ -7,4 +7,10 @@ import kotlinx.collections.immutable.ImmutableList
 @Immutable
 data class ChallengeRoutineUiState(
     val routines: ImmutableList<ChallengeRoutineModel>
-)
+) {
+    val selectedRoutine: ChallengeRoutineModel?
+        get() = routines.firstOrNull { it.isSelected }
+
+    val isSelected: Boolean
+        get() = selectedRoutine != null
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
@@ -1,0 +1,56 @@
+package com.cherrish.android.presentation.challenge.routine
+
+import androidx.lifecycle.ViewModel
+import com.cherrish.android.core.common.extension.updateSuccess
+import com.cherrish.android.core.common.state.UiState
+import com.cherrish.android.presentation.challenge.routine.model.ChallengeRoutineModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState =
+        MutableStateFlow<UiState<ChallengeRoutineUiState>>(UiState.Loading)
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        loadRoutines()
+    }
+
+    private fun loadRoutines() {
+        _uiState.value = UiState.Success(
+            ChallengeRoutineUiState(
+                routines = persistentListOf(
+                    ChallengeRoutineModel(id =1L, routine  = "피부 컨디션"),
+                    ChallengeRoutineModel(id =2L, routine = "생활 습관"),
+                    ChallengeRoutineModel(id=3L, routine ="체형 관리"),
+                    ChallengeRoutineModel(id=4L, routine = "웰니스 · 마음챙김")
+                )
+            )
+        )
+    }
+
+    fun onRoutineClick(id: Long) {
+        _uiState.updateSuccess { state ->
+            state.copy(
+                routines = state.routines.map {
+                    it.copy(isSelected = it.id == id)
+                }.toPersistentList()
+            )
+        }
+    }
+
+    fun onNextClick() {
+        val selectedRoutine = _uiState.value
+            .let { it as? UiState.Success }
+            ?.data
+            ?.routines
+            ?.firstOrNull { it.isSelected }
+            ?: return
+    }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
@@ -9,6 +9,7 @@ import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 @HiltViewModel
@@ -16,14 +17,14 @@ class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
 
     private val _uiState =
         MutableStateFlow<UiState<ChallengeRoutineUiState>>(UiState.Loading)
-    val uiState = _uiState.asStateFlow()
+    val uiState: StateFlow<UiState<ChallengeRoutineUiState>> = _uiState.asStateFlow()
 
     init {
         loadRoutines()
     }
 
     private fun loadRoutines() {
-        _uiState.value = UiState.Success(
+        _uiState.updateSuccess {
             ChallengeRoutineUiState(
                 routines = persistentListOf(
                     ChallengeRoutineModel(id = 1L, routine = "피부 컨디션"),
@@ -32,7 +33,7 @@ class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
                     ChallengeRoutineModel(id = 4L, routine = "웰니스 · 마음챙김")
                 )
             )
-        )
+        }
     }
 
     fun onRoutineClick(id: Long) {
@@ -53,4 +54,8 @@ class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
             ?.firstOrNull { it.isSelected }
             ?: return
     }
+
+    fun onBackCLick() {
+    }
+    fun onCloseClick() {}
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
@@ -5,11 +5,11 @@ import com.cherrish.android.core.common.extension.updateSuccess
 import com.cherrish.android.core.common.state.UiState
 import com.cherrish.android.presentation.challenge.routine.model.ChallengeRoutineModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import javax.inject.Inject
 
 @HiltViewModel
 class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
@@ -26,10 +26,10 @@ class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
         _uiState.value = UiState.Success(
             ChallengeRoutineUiState(
                 routines = persistentListOf(
-                    ChallengeRoutineModel(id =1L, routine  = "피부 컨디션"),
-                    ChallengeRoutineModel(id =2L, routine = "생활 습관"),
-                    ChallengeRoutineModel(id=3L, routine ="체형 관리"),
-                    ChallengeRoutineModel(id=4L, routine = "웰니스 · 마음챙김")
+                    ChallengeRoutineModel(id = 1L, routine = "피부 컨디션"),
+                    ChallengeRoutineModel(id = 2L, routine = "생활 습관"),
+                    ChallengeRoutineModel(id = 3L, routine = "체형 관리"),
+                    ChallengeRoutineModel(id = 4L, routine = "웰니스 · 마음챙김")
                 )
             )
         )

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
@@ -55,7 +55,7 @@ class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
         val selectedRoutine = state.data.selectedRoutine!!
     }
 
-    fun onBackCLick() {
+    fun onBackClick() {
     }
     fun onCloseClick() {}
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/ChallengeRoutineViewModel.kt
@@ -47,12 +47,12 @@ class ChallengeRoutineViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onNextClick() {
-        val selectedRoutine = _uiState.value
-            .let { it as? UiState.Success }
-            ?.data
-            ?.routines
-            ?.firstOrNull { it.isSelected }
-            ?: return
+        val state = _uiState.value
+
+        if (state !is UiState.Success) return
+        if (!state.data.isSelected) return
+
+        val selectedRoutine = state.data.selectedRoutine!!
     }
 
     fun onBackCLick() {

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/routine/model/ChallengeRoutineModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/routine/model/ChallengeRoutineModel.kt
@@ -6,5 +6,5 @@ import androidx.compose.runtime.Immutable
 data class ChallengeRoutineModel(
     val id: Long,
     val routine: String,
-    val isSelected: Boolean
+    val isSelected: Boolean = false
 )


### PR DESCRIPTION
## Related issue 🛠
- closed #42

## Work Description ✏️
 - 챌린지 뷰 스크린 구현 

## Screenshot 📸
[<img src="" width="360"/>
](https://github.com/user-attachments/assets/4e72d373-f751-438d-a142-77df37df2bbb)

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
챌린지 뷰 스크린을 구현하면서 UI State를 조금 변경했습니다 ! 그리고 에뮬레이터로 실행했을 때와 실물기기로 했을 때 기기 대응이 돼서 그런지 미션칩 크기가 조오금 다르더라고요 ,,!! 편히 확인해주세요요 !! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도전 루틴 선택 화면 추가
  * 여러 루틴 항목 표시 및 선택/토글 가능
  * 최소 하나 선택 시 활성화되는 "다음" 버튼
  * 화면 미리보기 추가로 선택 동작 및 비활성 상태 확인 가능

* **개선 / 리팩터**
  * 루틴 선택 상태를 불변 리스트 기반으로 통합 관리
  * 모델의 선택 필드에 기본값 추가로 사용 편의성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->