### PR TITLE
[FEAT/#92] 챌린지 미션 뷰 컴포넌트 조립 

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionOnboardingBody.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionOnboardingBody.kt
@@ -26,7 +26,7 @@ import kotlinx.collections.immutable.toPersistentList
 @Composable
 fun ChallengeMissionOnboardingBody(
     items: ImmutableList<ChallengeMissionModel>,
-    onItemClick: (Int) -> Unit,
+    onItemClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.fillMaxWidth()) {

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
@@ -87,12 +87,11 @@ private fun ChallengeMissionSelectedScreen(
 
         CherrishButton(
             text = "플래너에 추가하기",
-            enabled = uiState.hasSelected,
-            onClick = onAddTodoClick,
-            modifier = Modifier.padding(horizontal = 24.dp)
+            enabled = uiState.isSelected,
+            onClick = onAddTodoClick
         )
 
-        Spacer(Modifier.weight(30f))
+        Spacer(Modifier.height(30.dp))
     }
 }
 

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
@@ -72,8 +72,7 @@ private fun ChallengeMissionSelectedScreen(
         BackAndCloseTopAppBar(
             title = "TO-DO 미션 선택",
             onBackClick = onBackClick,
-            onCloseClick = onCloseClick,
-            modifier = Modifier.padding(horizontal = 9.dp)
+            onCloseClick = onCloseClick
         )
 
         Spacer(Modifier.height(44.dp))

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
@@ -1,6 +1,5 @@
 package com.cherrish.android.presentation.challenge.mission
 
-import android.widget.Space
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -8,9 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,11 +22,9 @@ import com.cherrish.android.core.designsystem.component.button.CherrishButton
 import com.cherrish.android.core.designsystem.component.topappbar.BackAndCloseTopAppBar
 import com.cherrish.android.core.designsystem.theme.CherrishTheme
 import com.cherrish.android.presentation.challenge.component.ChallengeMissionOnboardingBody
-import com.cherrish.android.presentation.challenge.mission.ChallengeMissionSelectedScreen
 import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-
 
 @Composable
 fun ChallengeMissionSelectedRoute(
@@ -38,8 +33,12 @@ fun ChallengeMissionSelectedRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     when (val state = uiState) {
-        is UiState.Loading -> {}
-        is UiState.Failure -> {}
+        is UiState.Loading -> {
+
+        }
+        is UiState.Failure -> {
+
+        }
         is UiState.Success -> {
             ChallengeMissionSelectedScreen(
                 uiState = state.data,
@@ -50,7 +49,6 @@ fun ChallengeMissionSelectedRoute(
                 onAddTodoClick = viewModel::onAddTodoClick
             )
         }
-
         else -> {}
     }
 }
@@ -69,7 +67,7 @@ private fun ChallengeMissionSelectedScreen(
         modifier = modifier
             .fillMaxSize()
             .background(CherrishTheme.colors.gray0)
-            .padding(paddingValues),
+            .padding(paddingValues)
     ) {
         Spacer(Modifier.height(44.dp))
 
@@ -147,7 +145,9 @@ private fun ChallengeMissionSelectedScreenPreview() {
                 missions = uiState.missions.map { mission ->
                     if (mission.id == clickedId) {
                         mission.copy(isSelected = !mission.isSelected)
-                    } else mission
+                    } else {
+                        mission
+                    }
                 }.toPersistentList()
             )
         },

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
@@ -1,0 +1,158 @@
+package com.cherrish.android.presentation.challenge.mission
+
+import android.widget.Space
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cherrish.android.core.common.state.UiState
+import com.cherrish.android.core.designsystem.component.button.CherrishButton
+import com.cherrish.android.core.designsystem.component.topappbar.BackAndCloseTopAppBar
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.presentation.challenge.component.ChallengeMissionOnboardingBody
+import com.cherrish.android.presentation.challenge.mission.ChallengeMissionSelectedScreen
+import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+
+
+@Composable
+fun ChallengeMissionSelectedRoute(
+    paddingValues: PaddingValues,
+    viewModel: ChallengeMissionViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    when (val state = uiState) {
+        is UiState.Loading -> {}
+        is UiState.Failure -> {}
+        is UiState.Success -> {
+            ChallengeMissionSelectedScreen(
+                uiState = state.data,
+                paddingValues = paddingValues,
+                onBackClick = viewModel::onBackClick,
+                onCloseClick = viewModel::onCloseClick,
+                onMissionClick = viewModel::onTodoMissionClick,
+                onAddTodoClick = viewModel::onAddTodoClick
+            )
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun ChallengeMissionSelectedScreen(
+    paddingValues: PaddingValues,
+    uiState: ChallengeMissionUiState,
+    onMissionClick: (Long) -> Unit,
+    onAddTodoClick: () -> Unit,
+    onBackClick: () -> Unit,
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(CherrishTheme.colors.gray0)
+            .padding(paddingValues),
+    ) {
+        Spacer(Modifier.height(44.dp))
+
+        BackAndCloseTopAppBar(
+            title = "TO-DO 미션 선택",
+            onBackClick = onBackClick,
+            onCloseClick = onCloseClick,
+            modifier = Modifier.padding(horizontal = 9.dp)
+        )
+
+        Spacer(Modifier.height(44.dp))
+
+        ChallengeMissionOnboardingBody(
+            items = uiState.missions,
+            onItemClick = onMissionClick,
+            modifier = Modifier.padding(horizontal = 26.dp)
+        )
+
+        Spacer(Modifier.weight(64f))
+
+        CherrishButton(
+            text = "플래너에 추가하기",
+            enabled = uiState.hasSelected,
+            onClick = onAddTodoClick,
+            modifier = Modifier.padding(horizontal = 24.dp)
+        )
+
+        Spacer(Modifier.weight(30f))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChallengeMissionSelectedScreenPreview() {
+
+    var uiState by remember {
+        mutableStateOf(
+            ChallengeMissionUiState(
+                missions = persistentListOf(
+                    ChallengeMissionModel(
+                        id = 1L,
+                        missionContent = "아침 세안 후 토너 바르기",
+                        isSelected = false
+                    ),
+                    ChallengeMissionModel(
+                        id = 2L,
+                        missionContent = "수분 에센스 2-3방울 흡수",
+                        isSelected = false
+                    ),
+                    ChallengeMissionModel(
+                        id = 3L,
+                        missionContent = "보습 크림으로 마무리",
+                        isSelected = false
+                    ),
+                    ChallengeMissionModel(
+                        id = 4L,
+                        missionContent = "저녁 클렌징 꼼꼼히 하기",
+                        isSelected = false
+                    ),
+                    ChallengeMissionModel(
+                        id = 5L,
+                        missionContent = "수분 마스크팩 (주 2-3회)",
+                        isSelected = false
+                    )
+                )
+            )
+        )
+    }
+
+    ChallengeMissionSelectedScreen(
+        paddingValues = PaddingValues(),
+        uiState = uiState,
+        onMissionClick = { clickedId ->
+            uiState = uiState.copy(
+                missions = uiState.missions.map { mission ->
+                    if (mission.id == clickedId) {
+                        mission.copy(isSelected = !mission.isSelected)
+                    } else mission
+                }.toPersistentList()
+            )
+        },
+        onAddTodoClick = {},
+        onBackClick = {},
+        onCloseClick = {}
+    )
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionSelectedScreen.kt
@@ -34,10 +34,8 @@ fun ChallengeMissionSelectedRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     when (val state = uiState) {
         is UiState.Loading -> {
-
         }
         is UiState.Failure -> {
-
         }
         is UiState.Success -> {
             ChallengeMissionSelectedScreen(
@@ -102,7 +100,6 @@ private fun ChallengeMissionSelectedScreen(
 @Preview(showBackground = true)
 @Composable
 private fun ChallengeMissionSelectedScreenPreview() {
-
     var uiState by remember {
         mutableStateOf(
             ChallengeMissionUiState(

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
@@ -3,13 +3,14 @@ package com.cherrish.android.presentation.challenge.mission
 import androidx.compose.runtime.Immutable
 import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toPersistentList
 
 @Immutable
 data class ChallengeMissionUiState(
     val missions: ImmutableList<ChallengeMissionModel>
 ) {
-    val selectedMissions: List<ChallengeMissionModel>
-        get() = missions.filter { it.isSelected }
+    val selectedMissions: ImmutableList<ChallengeMissionModel>
+        get() = missions.filter { it.isSelected }.toPersistentList()
 
     val hasSelected: Boolean
         get() = selectedMissions.isNotEmpty()

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
@@ -12,6 +12,6 @@ data class ChallengeMissionUiState(
     val selectedMissions: ImmutableList<ChallengeMissionModel>
         get() = missions.filter { it.isSelected }.toPersistentList()
 
-    val hasSelected: Boolean
+    val isSelected: Boolean
         get() = selectedMissions.isNotEmpty()
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
@@ -7,5 +7,11 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class ChallengeMissionUiState(
-    val missions: ImmutableList<ChallengeMissionModel> = persistentListOf()
-)
+    val missions: ImmutableList<ChallengeMissionModel>
+) {
+    val selectedMissions: List<ChallengeMissionModel>
+        get() = missions.filter { it.isSelected }
+
+    val hasSelected: Boolean
+        get() = selectedMissions.isNotEmpty()
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionUiState.kt
@@ -3,7 +3,6 @@ package com.cherrish.android.presentation.challenge.mission
 import androidx.compose.runtime.Immutable
 import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class ChallengeMissionUiState(

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
@@ -1,0 +1,66 @@
+package com.cherrish.android.presentation.challenge.mission
+
+import androidx.lifecycle.ViewModel
+import com.cherrish.android.core.common.extension.updateSuccess
+import com.cherrish.android.core.common.state.UiState
+import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class ChallengeMissionViewModel @Inject constructor() : ViewModel(){
+    private val _uiState =
+        MutableStateFlow<UiState<ChallengeMissionUiState>>(UiState.Loading)
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        loadMissions()
+    }
+
+    private fun loadMissions(){
+        _uiState.value = UiState.Success(
+            ChallengeMissionUiState(
+                missions = persistentListOf(   ChallengeMissionModel(1, "아침 세안 후 토너 바르기"),
+                    ChallengeMissionModel(2, "수분 에센스 2-3방울 흡수"),
+                    ChallengeMissionModel(3, "보습 크림으로 마무리"),
+                    ChallengeMissionModel(4, "저녁 클렌징 꼼꼼히 하기"),
+                    ChallengeMissionModel(5, "수분 마스크팩 (주 2-3회)")
+                )
+
+            )
+        )
+    }
+    fun onTodoMissionClick(id:Long){
+        _uiState.updateSuccess {
+            state -> state.copy(
+                missions = state.missions.map {
+                    mission -> if(mission.id==id){
+                        mission.copy(isSelected = !mission.isSelected)
+                }else {
+                    mission
+                }
+                }.toPersistentList()
+            )
+        }
+    }
+
+
+    fun onAddTodoClick() {
+        val state = _uiState.value
+
+        if (state !is UiState.Success) return
+
+        if (!state.data.hasSelected) return
+
+        state.data.selectedMissions
+
+    }
+    fun onBackClick(){}
+    fun onCloseClick(){}
+
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
@@ -53,7 +53,7 @@ class ChallengeMissionViewModel @Inject constructor() : ViewModel() {
 
     fun onAddTodoClick() {
         _uiState.updateSuccess { state ->
-            if (!state.hasSelected) return@updateSuccess state
+            if (!state.isSelected) return@updateSuccess state
 
             state.copy()
         }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
@@ -5,15 +5,14 @@ import com.cherrish.android.core.common.extension.updateSuccess
 import com.cherrish.android.core.common.state.UiState
 import com.cherrish.android.presentation.challenge.mission.model.ChallengeMissionModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import javax.inject.Inject
 
 @HiltViewModel
-class ChallengeMissionViewModel @Inject constructor() : ViewModel(){
+class ChallengeMissionViewModel @Inject constructor() : ViewModel() {
     private val _uiState =
         MutableStateFlow<UiState<ChallengeMissionUiState>>(UiState.Loading)
     val uiState = _uiState.asStateFlow()
@@ -22,10 +21,11 @@ class ChallengeMissionViewModel @Inject constructor() : ViewModel(){
         loadMissions()
     }
 
-    private fun loadMissions(){
+    private fun loadMissions() {
         _uiState.value = UiState.Success(
             ChallengeMissionUiState(
-                missions = persistentListOf(   ChallengeMissionModel(1, "아침 세안 후 토너 바르기"),
+                missions = persistentListOf(
+                    ChallengeMissionModel(1, "아침 세안 후 토너 바르기"),
                     ChallengeMissionModel(2, "수분 에센스 2-3방울 흡수"),
                     ChallengeMissionModel(3, "보습 크림으로 마무리"),
                     ChallengeMissionModel(4, "저녁 클렌징 꼼꼼히 하기"),
@@ -35,20 +35,21 @@ class ChallengeMissionViewModel @Inject constructor() : ViewModel(){
             )
         )
     }
-    fun onTodoMissionClick(id:Long){
+    fun onTodoMissionClick(id: Long) {
         _uiState.updateSuccess {
-            state -> state.copy(
+                state ->
+            state.copy(
                 missions = state.missions.map {
-                    mission -> if(mission.id==id){
+                        mission ->
+                    if (mission.id == id) {
                         mission.copy(isSelected = !mission.isSelected)
-                }else {
-                    mission
-                }
+                    } else {
+                        mission
+                    }
                 }.toPersistentList()
             )
         }
     }
-
 
     fun onAddTodoClick() {
         val state = _uiState.value
@@ -58,9 +59,7 @@ class ChallengeMissionViewModel @Inject constructor() : ViewModel(){
         if (!state.data.hasSelected) return
 
         state.data.selectedMissions
-
     }
-    fun onBackClick(){}
-    fun onCloseClick(){}
-
+    fun onBackClick() {}
+    fun onCloseClick() {}
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/ChallengeMissionViewModel.kt
@@ -9,31 +9,31 @@ import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 @HiltViewModel
 class ChallengeMissionViewModel @Inject constructor() : ViewModel() {
     private val _uiState =
         MutableStateFlow<UiState<ChallengeMissionUiState>>(UiState.Loading)
-    val uiState = _uiState.asStateFlow()
+    val uiState: StateFlow<UiState<ChallengeMissionUiState>> = _uiState.asStateFlow()
 
     init {
         loadMissions()
     }
 
     private fun loadMissions() {
-        _uiState.value = UiState.Success(
-            ChallengeMissionUiState(
+        _uiState.updateSuccess { state ->
+            state.copy(
                 missions = persistentListOf(
-                    ChallengeMissionModel(1, "아침 세안 후 토너 바르기"),
-                    ChallengeMissionModel(2, "수분 에센스 2-3방울 흡수"),
-                    ChallengeMissionModel(3, "보습 크림으로 마무리"),
-                    ChallengeMissionModel(4, "저녁 클렌징 꼼꼼히 하기"),
-                    ChallengeMissionModel(5, "수분 마스크팩 (주 2-3회)")
+                    ChallengeMissionModel(1L, "아침 세안 후 토너 바르기"),
+                    ChallengeMissionModel(2L, "수분 에센스 2-3방울 흡수"),
+                    ChallengeMissionModel(3L, "보습 크림으로 마무리"),
+                    ChallengeMissionModel(4L, "저녁 클렌징 꼼꼼히 하기"),
+                    ChallengeMissionModel(5L, "수분 마스크팩 (주 2-3회)")
                 )
-
             )
-        )
+        }
     }
     fun onTodoMissionClick(id: Long) {
         _uiState.updateSuccess {
@@ -52,13 +52,11 @@ class ChallengeMissionViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onAddTodoClick() {
-        val state = _uiState.value
+        _uiState.updateSuccess { state ->
+            if (!state.hasSelected) return@updateSuccess state
 
-        if (state !is UiState.Success) return
-
-        if (!state.data.hasSelected) return
-
-        state.data.selectedMissions
+            state.copy()
+        }
     }
     fun onBackClick() {}
     fun onCloseClick() {}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/mission/model/ChallengeMissionModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/mission/model/ChallengeMissionModel.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 data class ChallengeMissionModel(
-    val id: Int,
+    val id: Long,
     val missionContent: String,
-    val isSelected: Boolean
+    val isSelected: Boolean = false
 )


### PR DESCRIPTION
## Related issue 🛠
- closed #92 

## Work Description ✏️
- ChallengeMissionSelected 화면에 ViewModel을 적용하고 UiState 기반으로 상태 처리하도록 구조를 정리했습니다
- Route에서 상태 수집 및 이벤트 연결을 담당하고, Screen은 UI 렌더링만 수행하도록 책임을 분리했습니다
- 미션 선택, 뒤로가기, 닫기, 플래너 추가 액션을 ViewModel 이벤트로 위임해 단방향 데이터 흐름을 적용했습니다
- ktLint 실행 했습니다 

## Screenshot 📸

https://github.com/user-attachments/assets/9183ba9d-d86d-4a30-97ca-9dd8cb2b9c3a

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
나현티티 언니의 코드 보면서 구현하려고 노력했는데 알맞게 따라했는지 모르겠네요어 .. 코리 달아주세용 ~~~!! 달아주면 이번년도 해피한 일이 많으실거에요 !~ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 미션 선택 화면이 추가되었습니다.
  * 사용자는 미션을 선택해 플래너에 추가할 수 있으며, 선택된 항목이 화면에 명확히 표시됩니다.
  * 선택된 미션이 있을 때만 추가 버튼이 활성화됩니다.

* **수정 사항**
  * 미션 식별자 및 선택 상태 처리 방식이 변경되어 선택 관련 안정성과 일관성이 향상되었습니다.
  * UI 상태에서 선택된 항목 계산과 버튼 활성화 로직이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->