### PR TITLE
[FEAT/#95] 챌린지 미션프로그래스 뷰 컴포넌트 조립

### DIFF
--- a/app/src/main/java/com/cherrish/android/core/designsystem/component/button/CherrishButton.kt
+++ b/app/src/main/java/com/cherrish/android/core/designsystem/component/button/CherrishButton.kt
@@ -67,7 +67,7 @@ fun CherrishButton(
             .scale(scale)
             .clip(RoundedCornerShape(12.dp))
             .background(backgroundColor)
-            .padding(10.dp),
+            .padding(vertical = 10.dp),
         interactionSource = interactionSource
     ) {
         Text(

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionProgressCherrygrowth.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionProgressCherrygrowth.kt
@@ -90,7 +90,7 @@ fun ChallengeMissionProgressCherrygrowth(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 18.dp)
-                .padding(bottom = 9.dp)
+                .padding(bottom = 10.dp)
         )
     }
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionTodoSection.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionTodoSection.kt
@@ -63,7 +63,10 @@ fun ChallengeMissionTodoSection(
         CherrishButton(
             text = "오늘 미션 종료하기",
             onClick = onCompleteClick,
-            modifier = Modifier.padding(top = 10.dp)
+
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp)
         )
     }
 }
@@ -73,20 +76,6 @@ private fun ChallengeMissionTodoList(
     routines: ImmutableList<DailyTodoRoutineModel>,
     onRoutineClick: (Long) -> Unit
 ) {
-//    LazyColumn(
-//        verticalArrangement = Arrangement.spacedBy(8.dp)
-//    ) {
-//        items(
-//            items = routines,
-//            key = { it.id }
-//        ) { item ->
-//            ChallengeChecklist(
-//                isChecked = item.isCompleted,
-//                onChecklistClick = { onRoutineClick(item.id) },
-//                checklistContent = item.routine
-//            )
-//        }
-//    }
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionTodoSection.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/component/ChallengeMissionTodoSection.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -75,13 +73,24 @@ private fun ChallengeMissionTodoList(
     routines: ImmutableList<DailyTodoRoutineModel>,
     onRoutineClick: (Long) -> Unit
 ) {
-    LazyColumn(
+//    LazyColumn(
+//        verticalArrangement = Arrangement.spacedBy(8.dp)
+//    ) {
+//        items(
+//            items = routines,
+//            key = { it.id }
+//        ) { item ->
+//            ChallengeChecklist(
+//                isChecked = item.isCompleted,
+//                onChecklistClick = { onRoutineClick(item.id) },
+//                checklistContent = item.routine
+//            )
+//        }
+//    }
+    Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        items(
-            items = routines,
-            key = { it.id }
-        ) { item ->
+        routines.forEach { item ->
             ChallengeChecklist(
                 isChecked = item.isCompleted,
                 onChecklistClick = { onRoutineClick(item.id) },

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressUiState.kt
@@ -11,5 +11,9 @@ data class ChallengeMissionProgressUiState(
     val currentDay: Int,
     val cherryType: CherryType,
     val remainingCount: Int,
+    val progressPercentage: Int,
     val routines: ImmutableList<DailyTodoRoutineModel>
-)
+) {
+    val hasCompletedAny: Boolean
+        get() = routines.any { it.isCompleted }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressUiState.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressUiState.kt
@@ -13,6 +13,7 @@ data class ChallengeMissionProgressUiState(
     val remainingCount: Int,
     val progressPercentage: Int,
     val routines: ImmutableList<DailyTodoRoutineModel>
+
 ) {
     val hasCompletedAny: Boolean
         get() = routines.any { it.isCompleted }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
@@ -1,0 +1,67 @@
+package com.cherrish.android.presentation.challenge.missionprogress
+
+import androidx.lifecycle.ViewModel
+import com.cherrish.android.core.common.extension.updateSuccess
+import com.cherrish.android.core.common.state.UiState
+import com.cherrish.android.presentation.challenge.missionprogress.model.ChallengeInfoModel
+import com.cherrish.android.presentation.challenge.missionprogress.model.DailyTodoRoutineModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@HiltViewModel
+class ChallengeMissionProgressViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState =
+        MutableStateFlow<UiState<ChallengeMissionProgressUiState>>(UiState.Loading)
+    val uiState: StateFlow<UiState<ChallengeMissionProgressUiState>> =
+        _uiState.asStateFlow()
+
+    init {
+        loadMissions()
+    }
+
+    private fun loadMissions() {
+        _uiState.value = UiState.Success(
+            ChallengeMissionProgressUiState(
+                challenge = ChallengeInfoModel(
+                    id = 1L,
+                    challengeTitle = "피부 컨디션 챌린지",
+                    challengeTotalDays = 8
+                ),
+                currentDay = 8,
+                cherryType = CherryType.BBANGBBANG,
+                remainingCount = 3,
+                progressPercentage = 25,
+                routines = persistentListOf(
+                    DailyTodoRoutineModel(1L, "선크림 바르기", true),
+                    DailyTodoRoutineModel(2L, "진정 토너+세럼", false),
+                    DailyTodoRoutineModel(3L, "진정 토너+세럼", false),
+                    DailyTodoRoutineModel(4L, "진정 토너+세럼", false)
+                )
+            )
+        )
+    }
+    fun onTodoClick(id: Long) {
+        _uiState.updateSuccess { state ->
+            state.copy(
+                routines = state.routines.map {
+                    if (it.id == id) {
+                        it.copy(isCompleted = !it.isCompleted)
+                    } else {
+                        it
+                    }
+                }.toPersistentList()
+            )
+        }
+    }
+    fun onCompletedTodayClick() {
+        val state = _uiState.value
+        if (state !is UiState.Success) return
+        if (!state.data.hasCompletedAny) return
+    }
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
@@ -26,7 +26,7 @@ class ChallengeMissionProgressViewModel @Inject constructor() : ViewModel() {
     }
 
     private fun loadMissions() {
-        _uiState.value = UiState.Success(
+        _uiState.updateSuccess {
             ChallengeMissionProgressUiState(
                 challenge = ChallengeInfoModel(
                     id = 1L,
@@ -44,7 +44,7 @@ class ChallengeMissionProgressViewModel @Inject constructor() : ViewModel() {
                     DailyTodoRoutineModel(4L, "진정 토너+세럼", false)
                 )
             )
-        )
+        }
     }
 
     fun onTodoClick(id: Long) {

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
@@ -46,6 +46,7 @@ class ChallengeMissionProgressViewModel @Inject constructor() : ViewModel() {
             )
         )
     }
+
     fun onTodoClick(id: Long) {
         _uiState.updateSuccess { state ->
             state.copy(
@@ -59,6 +60,7 @@ class ChallengeMissionProgressViewModel @Inject constructor() : ViewModel() {
             )
         }
     }
+
     fun onCompletedTodayClick() {
         val state = _uiState.value
         if (state !is UiState.Success) return

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
@@ -2,6 +2,7 @@ package com.cherrish.android.presentation.challenge.missionprogress
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -70,16 +71,15 @@ private fun ChallengeMissionprogressScreen(
         modifier = modifier
             .fillMaxSize()
             .background(CherrishTheme.colors.gray100)
+            .padding(paddingValues)
             .navigationBarsPadding(),
-        contentPadding = PaddingValues(horizontal = 17.dp),
+        contentPadding = PaddingValues(top = 38.dp, start = 17.dp, end = 17.dp, bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         item {
-            Spacer(modifier = Modifier.height(38.dp))
-        }
-
-        item {
-            ChallengeMissionSelectedTitle()
+            ChallengeMissionSelectedTitle(
+                challengeName = uiState.challenge.challengeTitle
+            )
         }
 
         item {
@@ -87,7 +87,6 @@ private fun ChallengeMissionprogressScreen(
                 cherryType = uiState.cherryType,
                 remainingRoutines = uiState.remainingCount,
                 challengeProgress = uiState.progressPercentage,
-                modifier = Modifier.padding(bottom = 16.dp)
             )
         }
 
@@ -100,15 +99,15 @@ private fun ChallengeMissionprogressScreen(
                 modifier = Modifier.fillMaxWidth()
             )
         }
-
-        item {
-            Spacer(modifier = Modifier.height(24.dp))
-        }
     }
 }
 
 @Composable
-private fun ChallengeMissionSelectedTitle(modifier: Modifier = Modifier) {
+private fun ChallengeMissionSelectedTitle(
+    challengeName: String,
+    modifier: Modifier = Modifier,
+
+) {
     Row(
         modifier = modifier
             .fillMaxWidth(),
@@ -116,33 +115,38 @@ private fun ChallengeMissionSelectedTitle(modifier: Modifier = Modifier) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            "피부 컨디션 챌린지",
+            text = "${challengeName} 챌린지",
             style = CherrishTheme.typography.title1SB18,
             color = CherrishTheme.colors.gray1000
         )
 
-        Surface(
-            shape = RoundedCornerShape(4.dp),
-            border = BorderStroke(
-                width = 1.dp,
-                color = CherrishTheme.colors.gray700
-            ),
-            color = CherrishTheme.colors.gray100
-        ) {
-            Text(
-                text = "7일 플랜",
-                color = CherrishTheme.colors.gray700,
-                style = CherrishTheme.typography.body3M12,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
-            )
-        }
+        Text(
+            text = "7일 플랜",
+            color = CherrishTheme.colors.gray700,
+            style = CherrishTheme.typography.body3M12,
+            modifier = Modifier
+                .background(
+                    color = CherrishTheme.colors.gray100,
+                    shape = RoundedCornerShape(4.dp)
+                )
+                .border(
+                    width = 1.dp,
+                    color = CherrishTheme.colors.gray700,
+                    shape = RoundedCornerShape(4.dp)
+                )
+                .padding(horizontal = 8.dp, vertical = 3.dp)
+        )
+
     }
-}
+    }
+
 
 @Preview(showBackground = true)
 @Composable
 private fun ChallengeMissionSelectedTitlePreview() {
-    ChallengeMissionSelectedTitle()
+    ChallengeMissionSelectedTitle(
+        challengeName = "피부 컨디션"
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
@@ -127,7 +127,7 @@ private fun ChallengeMissionSelectedTitle(modifier: Modifier = Modifier) {
                 text = "7일 플랜",
                 color = CherrishTheme.colors.gray700,
                 style = CherrishTheme.typography.body3M12,
-                modifier = Modifier.padding(horizontal = 3.dp, vertical = 8.dp)
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
             )
         }
     }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
@@ -34,7 +34,8 @@ import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun ChallengeMissionprogressRoute(
-    paddingValues: PaddingValues, viewModel: ChallengeMissionProgressViewModel = hiltViewModel()
+    paddingValues: PaddingValues,
+    viewModel: ChallengeMissionProgressViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -99,7 +100,8 @@ private fun ChallengeMissionprogressScreen(
 
 @Composable
 private fun ChallengeMissionSelectedTitle(
-    challengeName: String, modifier: Modifier = Modifier
+    challengeName: String,
+    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -118,7 +120,8 @@ private fun ChallengeMissionSelectedTitle(
             style = CherrishTheme.typography.body3M12,
             modifier = Modifier
                 .background(
-                    color = CherrishTheme.colors.gray100, shape = RoundedCornerShape(4.dp)
+                    color = CherrishTheme.colors.gray100,
+                    shape = RoundedCornerShape(4.dp)
                 )
                 .border(
                     width = 1.dp,
@@ -145,7 +148,9 @@ private fun ChallengeMissionprogressScreenPreview() {
         mutableStateOf(
             ChallengeMissionProgressUiState(
                 challenge = ChallengeInfoModel(
-                    id = 1L, challengeTitle = "피부 컨디션 챌린지", challengeTotalDays = 7
+                    id = 1L,
+                    challengeTitle = "피부 컨디션 챌린지",
+                    challengeTotalDays = 7
                 ),
                 currentDay = 4,
                 cherryType = CherryType.BBANGBBANG,
@@ -153,17 +158,34 @@ private fun ChallengeMissionprogressScreenPreview() {
                 progressPercentage = 25,
                 routines = persistentListOf(
                     DailyTodoRoutineModel(
-                        id = 1L, routine = "아침 세안 후 토너 바르기", isCompleted = false
-                    ), DailyTodoRoutineModel(
-                        id = 2L, routine = "수분 에센스 2–3방울 흡수", isCompleted = false
-                    ), DailyTodoRoutineModel(
-                        id = 3L, routine = "보습 크림으로 마무리", isCompleted = false
-                    ), DailyTodoRoutineModel(
-                        id = 4L, routine = "외출 전 선크림 꼼꼼히 바르기", isCompleted = false
-                    ), DailyTodoRoutineModel(
-                        id = 5L, routine = "태양을 피하는 방법", isCompleted = false
-                    ), DailyTodoRoutineModel(
-                        id = 6L, routine = "나가지 않기", isCompleted = false
+                        id = 1L,
+                        routine = "아침 세안 후 토너 바르기",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 2L,
+                        routine = "수분 에센스 2–3방울 흡수",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 3L,
+                        routine = "보습 크림으로 마무리",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 4L,
+                        routine = "외출 전 선크림 꼼꼼히 바르기",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 5L,
+                        routine = "태양을 피하는 방법",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 6L,
+                        routine = "나가지 않기",
+                        isCompleted = false
                     )
                 )
             )
@@ -184,5 +206,6 @@ private fun ChallengeMissionprogressScreenPreview() {
                 }.toPersistentList()
             )
         },
-        onCompleteTodayClick = {})
+        onCompleteTodayClick = {}
+    )
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
@@ -1,0 +1,191 @@
+package com.cherrish.android.presentation.challenge.missionprogress
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cherrish.android.core.common.state.UiState
+import com.cherrish.android.core.designsystem.theme.CherrishTheme
+import com.cherrish.android.presentation.challenge.component.ChallengeMissionProgressCherrygrowth
+import com.cherrish.android.presentation.challenge.component.ChallengeMissionTodoSection
+import com.cherrish.android.presentation.challenge.missionprogress.model.ChallengeInfoModel
+import com.cherrish.android.presentation.challenge.missionprogress.model.DailyTodoRoutineModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+
+@Composable
+fun ChallengeMissionprogressRoute(
+    paddingValues: PaddingValues,
+    viewModel: ChallengeMissionProgressViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is UiState.Loading -> Unit
+        is UiState.Failure -> Unit
+        is UiState.Success -> {
+            ChallengeMissionprogressScreen(
+                paddingValues = paddingValues,
+                uiState = state.data,
+                onTodoClick = viewModel::onTodoClick,
+                onCompleteTodayClick = viewModel::onCompletedTodayClick
+            )
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun ChallengeMissionprogressScreen(
+    paddingValues: PaddingValues,
+    uiState: ChallengeMissionProgressUiState,
+    onTodoClick: (Long) -> Unit,
+    onCompleteTodayClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 17.dp)
+            .padding(paddingValues)
+            .navigationBarsPadding()
+            .background(CherrishTheme.colors.gray100)
+    ) {
+        Spacer(modifier = Modifier.weight(38f))
+
+        ChallengeMissionSelectedTitle()
+
+        Spacer(modifier = Modifier.weight(14f))
+
+        ChallengeMissionProgressCherrygrowth(
+            cherryType = uiState.cherryType,
+            remainingRoutines = uiState.remainingCount,
+            challengeProgress = uiState.progressPercentage,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Spacer(modifier = Modifier.weight(14f))
+
+        ChallengeMissionTodoSection(
+            routines = uiState.routines,
+            currentDay = uiState.currentDay,
+            onRoutineClick = onTodoClick,
+            onCompleteClick = onCompleteTodayClick,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.weight(24f))
+    }
+}
+
+@Composable
+private fun ChallengeMissionSelectedTitle(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            "피부 컨디션 챌린지",
+            style = CherrishTheme.typography.title1SB18,
+            color = CherrishTheme.colors.gray1000
+        )
+
+        Surface(
+            modifier = Modifier,
+            shape = RoundedCornerShape(4.dp),
+            border = BorderStroke(
+                width = 1.dp,
+                color = CherrishTheme.colors.gray700
+            ),
+            color = CherrishTheme.colors.gray100
+        ) {
+            Text(
+                text = "7일 플랜",
+                color = CherrishTheme.colors.gray700,
+                style = CherrishTheme.typography.body3M12,
+                modifier = Modifier.padding(horizontal = 3.dp, vertical = 8.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChallengeMissionSelectedTitlePreview() {
+    ChallengeMissionSelectedTitle()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChallengeMissionprogressScreenPreview() {
+    var uiState by remember {
+        mutableStateOf(
+            ChallengeMissionProgressUiState(
+                challenge = ChallengeInfoModel(
+                    id = 1L,
+                    challengeTitle = "피부 컨디션 챌린지",
+                    challengeTotalDays = 7
+                ),
+                currentDay = 4,
+                cherryType = CherryType.BBANGBBANG,
+                remainingCount = 3,
+                progressPercentage = 25,
+                routines = persistentListOf(
+                    DailyTodoRoutineModel(id = 1L, routine = "아침 세안 후 토너 바르기", isCompleted = false),
+                    DailyTodoRoutineModel(
+                        id = 2L,
+                        routine = "수분 에센스 2–3방울 흡수",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(id = 3L, routine = "보습 크림으로 마무리", isCompleted = false),
+                    DailyTodoRoutineModel(
+                        id = 4L,
+                        routine = "외출 전 선크림 꼼꼼히 바르기",
+                        isCompleted = false
+                    )
+                )
+            )
+        )
+    }
+
+    ChallengeMissionprogressScreen(
+        paddingValues = PaddingValues(),
+        uiState = uiState,
+        onTodoClick = { clickedId ->
+            uiState = uiState.copy(
+                routines = uiState.routines.map {
+                    if (it.id == clickedId) {
+                        it.copy(isCompleted = !it.isCompleted)
+                    } else {
+                        it
+                    }
+                }.toPersistentList()
+            )
+        },
+        onCompleteTodayClick = {}
+    )
+}

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
@@ -1,20 +1,16 @@
 package com.cherrish.android.presentation.challenge.missionprogress
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,14 +34,13 @@ import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun ChallengeMissionprogressRoute(
-    paddingValues: PaddingValues,
-    viewModel: ChallengeMissionProgressViewModel = hiltViewModel()
+    paddingValues: PaddingValues, viewModel: ChallengeMissionProgressViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     when (val state = uiState) {
-        is UiState.Loading -> Unit
-        is UiState.Failure -> Unit
+        is UiState.Loading -> {}
+        is UiState.Failure -> {}
         is UiState.Success -> {
             ChallengeMissionprogressScreen(
                 paddingValues = paddingValues,
@@ -86,7 +81,7 @@ private fun ChallengeMissionprogressScreen(
             ChallengeMissionProgressCherrygrowth(
                 cherryType = uiState.cherryType,
                 remainingRoutines = uiState.remainingCount,
-                challengeProgress = uiState.progressPercentage,
+                challengeProgress = uiState.progressPercentage
             )
         }
 
@@ -104,18 +99,15 @@ private fun ChallengeMissionprogressScreen(
 
 @Composable
 private fun ChallengeMissionSelectedTitle(
-    challengeName: String,
-    modifier: Modifier = Modifier,
-
+    challengeName: String, modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = "${challengeName} 챌린지",
+            text = "$challengeName 챌린지",
             style = CherrishTheme.typography.title1SB18,
             color = CherrishTheme.colors.gray1000
         )
@@ -126,8 +118,7 @@ private fun ChallengeMissionSelectedTitle(
             style = CherrishTheme.typography.body3M12,
             modifier = Modifier
                 .background(
-                    color = CherrishTheme.colors.gray100,
-                    shape = RoundedCornerShape(4.dp)
+                    color = CherrishTheme.colors.gray100, shape = RoundedCornerShape(4.dp)
                 )
                 .border(
                     width = 1.dp,
@@ -136,10 +127,8 @@ private fun ChallengeMissionSelectedTitle(
                 )
                 .padding(horizontal = 8.dp, vertical = 3.dp)
         )
-
     }
-    }
-
+}
 
 @Preview(showBackground = true)
 @Composable
@@ -156,9 +145,7 @@ private fun ChallengeMissionprogressScreenPreview() {
         mutableStateOf(
             ChallengeMissionProgressUiState(
                 challenge = ChallengeInfoModel(
-                    id = 1L,
-                    challengeTitle = "피부 컨디션 챌린지",
-                    challengeTotalDays = 7
+                    id = 1L, challengeTitle = "피부 컨디션 챌린지", challengeTotalDays = 7
                 ),
                 currentDay = 4,
                 cherryType = CherryType.BBANGBBANG,
@@ -166,34 +153,17 @@ private fun ChallengeMissionprogressScreenPreview() {
                 progressPercentage = 25,
                 routines = persistentListOf(
                     DailyTodoRoutineModel(
-                        id = 1L,
-                        routine = "아침 세안 후 토너 바르기",
-                        isCompleted = false
-                    ),
-                    DailyTodoRoutineModel(
-                        id = 2L,
-                        routine = "수분 에센스 2–3방울 흡수",
-                        isCompleted = false
-                    ),
-                    DailyTodoRoutineModel(
-                        id = 3L,
-                        routine = "보습 크림으로 마무리",
-                        isCompleted = false
-                    ),
-                    DailyTodoRoutineModel(
-                        id = 4L,
-                        routine = "외출 전 선크림 꼼꼼히 바르기",
-                        isCompleted = false
-                    ),
-                    DailyTodoRoutineModel(
-                        id = 5L,
-                        routine = "태양을 피하는 방법",
-                        isCompleted = false
-                    ),
-                    DailyTodoRoutineModel(
-                        id = 6L,
-                        routine = "나가지 않기",
-                        isCompleted = false
+                        id = 1L, routine = "아침 세안 후 토너 바르기", isCompleted = false
+                    ), DailyTodoRoutineModel(
+                        id = 2L, routine = "수분 에센스 2–3방울 흡수", isCompleted = false
+                    ), DailyTodoRoutineModel(
+                        id = 3L, routine = "보습 크림으로 마무리", isCompleted = false
+                    ), DailyTodoRoutineModel(
+                        id = 4L, routine = "외출 전 선크림 꼼꼼히 바르기", isCompleted = false
+                    ), DailyTodoRoutineModel(
+                        id = 5L, routine = "태양을 피하는 방법", isCompleted = false
+                    ), DailyTodoRoutineModel(
+                        id = 6L, routine = "나가지 않기", isCompleted = false
                     )
                 )
             )
@@ -214,6 +184,5 @@ private fun ChallengeMissionprogressScreenPreview() {
                 }.toPersistentList()
             )
         },
-        onCompleteTodayClick = {}
-    )
+        onCompleteTodayClick = {})
 }

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionprogressScreen.kt
@@ -3,14 +3,15 @@ package com.cherrish.android.presentation.challenge.missionprogress
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -65,38 +66,44 @@ private fun ChallengeMissionprogressScreen(
     onCompleteTodayClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    LazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 17.dp)
-            .padding(paddingValues)
-            .navigationBarsPadding()
             .background(CherrishTheme.colors.gray100)
+            .navigationBarsPadding(),
+        contentPadding = PaddingValues(horizontal = 17.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
-        Spacer(modifier = Modifier.weight(38f))
+        item {
+            Spacer(modifier = Modifier.height(38.dp))
+        }
 
-        ChallengeMissionSelectedTitle()
+        item {
+            ChallengeMissionSelectedTitle()
+        }
 
-        Spacer(modifier = Modifier.weight(14f))
+        item {
+            ChallengeMissionProgressCherrygrowth(
+                cherryType = uiState.cherryType,
+                remainingRoutines = uiState.remainingCount,
+                challengeProgress = uiState.progressPercentage,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
 
-        ChallengeMissionProgressCherrygrowth(
-            cherryType = uiState.cherryType,
-            remainingRoutines = uiState.remainingCount,
-            challengeProgress = uiState.progressPercentage,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
+        item {
+            ChallengeMissionTodoSection(
+                routines = uiState.routines,
+                currentDay = uiState.currentDay,
+                onRoutineClick = onTodoClick,
+                onCompleteClick = onCompleteTodayClick,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
 
-        Spacer(modifier = Modifier.weight(14f))
-
-        ChallengeMissionTodoSection(
-            routines = uiState.routines,
-            currentDay = uiState.currentDay,
-            onRoutineClick = onTodoClick,
-            onCompleteClick = onCompleteTodayClick,
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(modifier = Modifier.weight(24f))
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+        }
     }
 }
 
@@ -115,7 +122,6 @@ private fun ChallengeMissionSelectedTitle(modifier: Modifier = Modifier) {
         )
 
         Surface(
-            modifier = Modifier,
             shape = RoundedCornerShape(4.dp),
             border = BorderStroke(
                 width = 1.dp,
@@ -155,16 +161,34 @@ private fun ChallengeMissionprogressScreenPreview() {
                 remainingCount = 3,
                 progressPercentage = 25,
                 routines = persistentListOf(
-                    DailyTodoRoutineModel(id = 1L, routine = "아침 세안 후 토너 바르기", isCompleted = false),
+                    DailyTodoRoutineModel(
+                        id = 1L,
+                        routine = "아침 세안 후 토너 바르기",
+                        isCompleted = false
+                    ),
                     DailyTodoRoutineModel(
                         id = 2L,
                         routine = "수분 에센스 2–3방울 흡수",
                         isCompleted = false
                     ),
-                    DailyTodoRoutineModel(id = 3L, routine = "보습 크림으로 마무리", isCompleted = false),
+                    DailyTodoRoutineModel(
+                        id = 3L,
+                        routine = "보습 크림으로 마무리",
+                        isCompleted = false
+                    ),
                     DailyTodoRoutineModel(
                         id = 4L,
                         routine = "외출 전 선크림 꼼꼼히 바르기",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 5L,
+                        routine = "태양을 피하는 방법",
+                        isCompleted = false
+                    ),
+                    DailyTodoRoutineModel(
+                        id = 6L,
+                        routine = "나가지 않기",
                         isCompleted = false
                     )
                 )
@@ -173,7 +197,7 @@ private fun ChallengeMissionprogressScreenPreview() {
     }
 
     ChallengeMissionprogressScreen(
-        paddingValues = PaddingValues(),
+        paddingValues = PaddingValues(0.dp),
         uiState = uiState,
         onTodoClick = { clickedId ->
             uiState = uiState.copy(


### PR DESCRIPTION
## Related issue 🛠
- closed #95

## Work Description ✏️

- 챌린지 미션 진행 화면 UI 구현
- LazyColumn 기반 전체 스크롤 구조로 전환
- TO-DO 미션 리스트 체크/해제 상태 관리 연결
- 서버 응답 기반 진행률(progressPercentage) 반영
- 체리 성장 영역, 미션 카드, 완료 버튼 컴포넌트 연동
- CherrishButton 변경 
- ktLint 실행  
- 

## Screenshot 📸

https://github.com/user-attachments/assets/dec8231c-3343-4ade-bdf7-a7399e7e55fd


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
사랑합니다 나.소.수 언니들 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Challenge Mission Progress 화면 추가: 도전 과제 진행을 한눈에 확인할 수 있습니다.
  * 일일 할일 항목을 탭해 완료 상태를 토글할 수 있습니다.
  * 전체 진행률(%) 및 완료된 항목 요약이 화면에 표시됩니다.

* **UI 개선**
  * 할일 섹션의 버튼이 화면 너비에 맞춰 표시되도록 변경되었습니다.
  * 일부 컴포넌트의 세로 여백이 소폭 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->