### PR TITLE
[FIX/#129] 챌린지 종료시 챌린지 시작 화면 이동

### DIFF
--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
@@ -121,7 +121,9 @@ class ChallengeMissionProgressViewModel @Inject constructor(
                     }
                     .onLogFailure { e ->
                         if (e is retrofit2.HttpException && e.code() == 404) {
-                            _sideEffect.emit(ChallengeMissionProgressSideEffect.NavigateToChallengeStart)
+                            _sideEffect.emit(
+                                ChallengeMissionProgressSideEffect.NavigateToChallengeStart
+                            )
                         }
                     }
             } finally {

--- a/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
+++ b/app/src/main/java/com/cherrish/android/presentation/challenge/missionprogress/ChallengeMissionProgressViewModel.kt
@@ -119,7 +119,11 @@ class ChallengeMissionProgressViewModel @Inject constructor(
                             )
                         }
                     }
-                    .onLogFailure { }
+                    .onLogFailure { e ->
+                        if (e is retrofit2.HttpException && e.code() == 404) {
+                            _sideEffect.emit(ChallengeMissionProgressSideEffect.NavigateToChallengeStart)
+                        }
+                    }
             } finally {
                 isPostingAdvanceDay = false
             }


### PR DESCRIPTION
## Related issue 🛠
- closed #129 

## Work Description ✏️
 - 챌린지 종료시 챌린지 시작 화면 이동

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢
급하게 해결한 거라 qa 끝나고 로직 수정해야할 것 같아요 cc. @hyeminililo  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 도전 과제 진행 처리 중 HTTP 404 오류 발생 시 사용자가 도전 시작 페이지로 자동 이동하도록 수정되었습니다. 이전에는 해당 오류가 무시되었으나, 이제 404에 한해 적절히 리디렉션됩니다. 성공 및 로딩 관련 동작에는 변경이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->